### PR TITLE
feat: Refactor article detail navigation and state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
---- START OF FILE README.md ---
-
 # Tackle4Loss
-
 This repository contains the Flutter frontend application for Tackle4Loss, an American Football news application built for iOS, Android, and Web platforms.
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+--- START OF FILE README.md ---
+
 # Tackle4Loss
 
 This repository contains the Flutter frontend application for Tackle4Loss, an American Football news application built for iOS, Android, and Web platforms.
@@ -13,12 +15,14 @@ This repository contains the Flutter frontend application for Tackle4Loss, an Am
 7.  [Architecture & Key Concepts](#architecture--key-concepts)
     *   [State Management (Riverpod)](#state-management-riverpod)
     *   [Backend Integration (Supabase)](#backend-integration-supabase)
-    *   [Navigation (Adaptive)](#navigation-adaptive)
+    *   [Navigation (State-Driven Inline Detail View)](#navigation-state-driven-inline-detail-view)
     *   [Theming & Styling](#theming--styling)
     *   [Data Fetching & Services](#data-fetching--services)
     *   [Localization](#localization)
     *   [Local Persistence](#local-persistence)
     *   [Responsiveness](#responsiveness)
+    *   [HTML Content Rendering](#html-content-rendering)
+    *   [Sharing](#sharing)
 8.  [Implemented Features](#implemented-features)
 9.  [Running the App](#running-the-app)
 10. [Backend Notes](#backend-notes)
@@ -26,7 +30,7 @@ This repository contains the Flutter frontend application for Tackle4Loss, an Am
 
 ## Overview
 
-Tackle4Loss aims to provide users with up-to-date American Football news currated from different NFL Source News Sites like NFL.com or ESPN.com. 
+Tackle4Loss aims to provide users with up-to-date American Football news curated from different NFL Source News Sites like NFL.com or ESPN.com.
 This Flutter application serves as the user interface, interacting with a Supabase backend for data storage, retrieval (via Edge Functions), and potentially authentication and real-time updates. The app is designed to be responsive, adapting its layout for mobile, tablet, and web screens.
 
 ## Prerequisites
@@ -46,8 +50,8 @@ This Flutter application serves as the user interface, interacting with a Supaba
 1.  **Clone the repository:**
     ```bash
     git clone https://github.com/BigSlikTobi/tackle_4_loss.git
-    cd tackle_4_loss 
-
+    cd tackle_4_loss
+    ```
 2.  **Install dependencies:**
     ```bash
     flutter pub get
@@ -100,20 +104,24 @@ The project follows a **Feature-First** architecture within the `lib` directory:
     *   `core/`: Shared code across features.
         *   `constants/`: App-wide constants (e.g., `team_constants.dart`).
         *   `models/`: Shared data models (if any).
-        *   `navigation/`: Navigation setup (`NavItem`, `MainNavigationWrapper`).
-        *   `providers/`: Shared Riverpod providers (e.g., `locale_provider.dart`, `navigation_provider.dart`).
+        *   `navigation/`: Navigation setup (`NavItem`, `MainNavigationWrapper`, `app_navigation.dart`).
+        *   `providers/`: Shared Riverpod providers (e.g., `locale_provider.dart`, `navigation_provider.dart`, `preference_provider.dart`).
         *   `services/`: Shared services (e.g., `preference_service.dart`).
         *   `theme/`: Global theme data (`app_colors.dart`, `app_theme.dart`).
         *   `utils/`: Utility functions.
-        *   `widgets/`: Common reusable widgets (e.g., `GlobalAppBar`, `LoadingIndicator`).
+        *   `widgets/`: Common reusable widgets (e.g., `GlobalAppBar`, `LoadingIndicator`, `ErrorMessageWidget`).
     *   `features/`: Feature modules.
         *   `news_feed/`
             *   `data/`: Models (`ArticlePreview`), Services (`NewsFeedService`).
-            *   `logic/`: Riverpod Providers (`news_feed_provider.dart`).
+            *   `logic/`: Riverpod Providers (`news_feed_provider.dart`, `news_feed_state.dart`).
             *   `ui/`: Screens (`NewsFeedScreen`), Widgets (`ArticleListItem`, `HeadlineStoryCard`).
         *   `my_team/`
+            *   `data/`: (If models/services specific to this feature are added)
+            *   `logic/`: (If providers specific to this feature are added)
             *   `ui/`: Screens (`MyTeamScreen`), Widgets (`UpcomingGamesCard`, `InjuryReportCard`, `TeamHuddleSection`, `TeamSelectionDropdown`).
-        *   `article_detail/`: Placeholder for future implementation.
+        *   `article_detail/`
+            *   `data/`: Models (`ArticleDetail`), Services (`ArticleDetailService`).
+            *   `logic/`: Riverpod Providers (`article_detail_provider.dart`).
             *   `ui/`: Screens (`ArticleDetailScreen`).
         *   `schedule/`: Placeholder.
             *   `ui/`: Screens (`ScheduleScreen`).
@@ -127,16 +135,19 @@ The project follows a **Feature-First** architecture within the `lib` directory:
 *   **Dart:** Programming language for Flutter.
 *   **Supabase:** Backend-as-a-Service:
     *   **Database:** PostgreSQL for data storage.
-    *   **Edge Functions:** Deno runtime for serverless backend logic (used for data fetching).
+    *   **Edge Functions:** Deno runtime for serverless backend logic (used for `articlePreviews`, `articleDetail`).
     *   **Auth (Setup for):** Supabase Auth for user management (not fully implemented in UI yet).
     *   **Storage:** For storing images (used by backend Python scripts).
     *   **Realtime (Setup for):** For potential live updates.
 *   **Riverpod (`flutter_riverpod`):** State management and dependency injection. Chosen for its robustness, testability, and excellent handling of async operations.
 *   **Supabase Flutter (`supabase_flutter`):** Official Supabase client library for Flutter.
-*   **Shared Preferences (`shared_preferences`):** Local key-value storage for persisting non-critical user preferences (selected team, language) without requiring login.
+*   **Shared Preferences (`shared_preferences`):** Local key-value storage for persisting non-critical user preferences (selected team, language).
 *   **Cached Network Image (`cached_network_image`):** Efficiently loads and caches network images.
-*   **intl (`intl`):** Used for date formatting and potentially future localization strings.
+*   **intl (`intl`):** Used for date formatting and localization support.
 *   **Flutter DotEnv (`flutter_dotenv`):** Loads environment variables from a `.env` file for secure credential management.
+*   **Flutter HTML (`flutter_html`):** Renders HTML content within Flutter widgets, used for article bodies.
+*   **URL Launcher (`url_launcher`):** Launches URLs in the default browser (used for source links in articles).
+*   **Share Plus (`share_plus`):** Invokes the native platform sharing UI.
 
 ## Architecture & Key Concepts
 
@@ -145,112 +156,130 @@ The project follows a **Feature-First** architecture within the `lib` directory:
 *   Uses `ProviderScope` at the root (`main.dart`).
 *   Widgets that need to read or interact with state use `ConsumerWidget` or `ConsumerStatefulWidget`.
 *   **Providers Used:**
-    *   `Provider`: For simple dependency injection (e.g., `newsFeedServiceProvider`, `preferenceServiceProvider`).
-    *   `StateProvider`: For simple synchronous state that needs to be mutated (e.g., `selectedNavIndexProvider`, `newsFeedDisplayModeProvider`, `isSidebarExtendedProvider` - though last was removed).
-    *   `FutureProvider`: For one-off async operations, automatically handling loading/error states (e.g., initial version of `articlePreviewsProvider`, `selectedTeamProvider`).
-    *   `StateNotifierProvider`/`AsyncNotifierProvider`: For more complex state involving asynchronous operations, user actions, and managing loading/error states robustly (e.g., `localeNotifierProvider`, `selectedTeamNotifierProvider`, `paginatedArticlesProvider`).
+    *   `Provider`: For simple dependency injection (e.g., `newsFeedServiceProvider`, `articleDetailServiceProvider`, `preferenceServiceProvider`).
+    *   `StateProvider`: For simple synchronous state (e.g., `selectedNavIndexProvider`, `newsFeedDisplayModeProvider`, `currentDetailArticleIdProvider`).
+    *   `FutureProvider`: Used previously, potentially useful for one-off async reads.
+    *   `FutureProvider.family`: For fetching async data based on a parameter (e.g., `articleDetailProvider(articleId)`).
+    *   `StateNotifierProvider`/`AsyncNotifierProvider`: For more complex state involving async operations, pagination, user actions, and robust loading/error management (e.g., `localeNotifierProvider`, `selectedTeamNotifierProvider`, `paginatedArticlesProvider`).
 
 ### Backend Integration (Supabase)
 
-*   Flutter app interacts with Supabase primarily through **Edge Functions**.
-*   Edge Functions (`articlePreviews`, etc.) are responsible for querying the database and returning structured data (often lean/preview data).
+*   Flutter app interacts with Supabase primarily through **Edge Functions** (e.g., `articlePreviews`, `articleDetail`).
+*   Edge Functions are responsible for querying the database and returning structured data.
 *   **Security (RLS):**
-    *   Row Level Security (RLS) is **ENABLED** on relevant database tables (`NewsArticles`, `TeamNewsArticles`, `Rosters`, etc.).
+    *   Row Level Security (RLS) is **ENABLED** on relevant database tables.
     *   Public read policies (`SELECT` for `public` role) are defined based on data status (e.g., `status = 'PUBLISHED'`).
     *   Edge Functions called by the Flutter app **use the client's authentication context** (via the `SUPABASE_ANON_KEY` and the `Authorization` header) to ensure RLS policies are enforced.
-    *   Backend Python scripts use the `SUPABASE_SERVICE_ROLE_KEY` to bypass RLS for administrative tasks (data ingestion, processing, updates).
+    *   Backend Python scripts use the `SUPABASE_SERVICE_ROLE_KEY` to bypass RLS for administrative tasks.
 
-### Navigation (Adaptive)
+### Navigation (State-Driven Inline Detail View)
 
-*   A central `MainNavigationWrapper` widget handles the primary app navigation structure.
-*   It adapts based on screen width (`kMobileLayoutBreakpoint`):
-    *   **Mobile (< 720px):** Displays a `BottomNavigationBar`.
-    *   **Desktop/Tablet (>= 720px):** Displays a `Drawer` accessible via a menu icon in the `GlobalAppBar`.
-*   `selectedNavIndexProvider` (StateProvider) tracks the active screen.
-*   `IndexedStack` preserves the state of each main screen when switching tabs/drawer items.
+*   A central `MainNavigationWrapper` widget handles the primary app structure and the persistent `GlobalAppBar`.
+*   It adapts the *base* navigation elements based on screen width (`kMobileLayoutBreakpoint`):
+    *   **Mobile (< 720px):** Displays a `BottomNavigationBar` *only* when not viewing article details.
+    *   **Desktop/Tablet (>= 720px):** Displays a persistent `Drawer` accessible via the menu icon in the `GlobalAppBar`.
+*   The main body content is controlled by the `currentDetailArticleIdProvider` (StateProvider):
+    *   If `null`, the `IndexedStack` containing the main screens (`NewsFeedScreen`, `MyTeamScreen`, etc., selected via `selectedNavIndexProvider`) is shown.
+    *   If an `articleId` is set, the `ArticleDetailScreen` (without its own Scaffold/AppBar) is displayed directly in the body.
+*   Navigation *to* the detail screen occurs by setting the `currentDetailArticleIdProvider` state.
+*   Navigation *back* from the detail screen occurs via an inline back button within `ArticleDetailScreen` that resets the `currentDetailArticleIdProvider` state to `null`.
+*   This approach keeps the `GlobalAppBar` (with logo, title, potential menu/share/refresh actions) constant across views.
 
 ### Theming & Styling
 
 *   A global theme is defined in `lib/core/theme/app_theme.dart` using `ThemeData`.
-*   Colors are centralized in `lib/core/theme/app_colors.dart` based on the provided style sheet.
-*   A custom `GlobalAppBar` (`lib/core/widgets/global_app_bar.dart`) provides a consistent header across screens, styled according to the theme.
-*   Widgets aim to use `Theme.of(context)` to access styles for consistency.
+*   Colors are centralized in `lib/core/theme/app_colors.dart`.
+*   A custom `GlobalAppBar` (`lib/core/widgets/global_app_bar.dart`) provides a consistent header. Actions (like share/refresh) are conditionally added within `MainNavigationWrapper`.
+*   Widgets aim to use `Theme.of(context)` for consistency.
+*   `flutter_html` uses `Style` objects to apply theme styles to rendered HTML content.
 
 ### Data Fetching & Services
 
-*   Network calls to Supabase Edge Functions are encapsulated within **Service classes** (e.g., `NewsFeedService`) located in the `data` folder of relevant features.
-*   Riverpod providers (`newsFeedServiceProvider`) are used to provide instances of these services.
-*   Widgets interact with providers, which in turn call services to fetch or manipulate data.
+*   Network calls to Supabase Edge Functions are encapsulated within **Service classes** (e.g., `NewsFeedService`, `ArticleDetailService`) located in the `data` folder of relevant features.
+*   Riverpod providers (`newsFeedServiceProvider`, `articleDetailServiceProvider`) provide service instances.
+*   Widgets interact with providers (`paginatedArticlesProvider`, `articleDetailProvider`), which handle async states and call services.
 
 ### Localization
 
-*   Basic localization setup using `flutter_localizations` is configured in `MaterialApp`.
-*   Supported locales are English (`en`) and German (`de`).
-*   `localeNotifierProvider` (StateNotifierProvider) manages the current app locale.
-*   It detects the initial device locale if no preference is saved.
-*   User selection is saved using `shared_preferences`.
-*   Widgets watch the provider to display content (e.g., headlines) in the appropriate language.
+*   Basic setup using `flutter_localizations` and `intl` for date formatting.
+*   Supported locales: English (`en`), German (`de`).
+*   `localeNotifierProvider` manages the current app locale, persisted via `shared_preferences`.
+*   Widgets (like `ArticleListItem`, `HeadlineStoryCard`, `ArticleDetailScreen`) use the current locale to display appropriate text (headlines, content, dates).
 
 ### Local Persistence
 
-*   `shared_preferences` is used to store:
+*   `shared_preferences` is used via `PreferenceService` to store:
     *   User's selected language override.
-    *   User's selected favorite team ID (allowing personalization without login).
-*   A `PreferenceService` (`lib/core/services/preference_service.dart`) wraps `shared_preferences` calls.
+    *   User's selected favorite team ID.
 
 ### Responsiveness
 
 *   **Layout Adaptation:** `MainNavigationWrapper` switches between bottom navigation and a drawer based on screen width.
-*   **Content Constraint:** On wider screens, the main content area is centered and constrained to a maximum width (`kMaxContentWidth`) using `Center` and `ConstrainedBox`.
-*   **Widget Adaptation:** Specific widgets (like the `TeamHuddleSection`'s sub-cards) adjust their internal layout (e.g., `Row` vs. `Column`) based on screen width.
+*   **Content Constraint:** On wider screens, the main content area (including the `ArticleDetailScreen` content) is centered and constrained to a maximum width (`kMaxContentWidth`).
+*   **Widget Adaptation:** Specific widgets might adjust internally (e.g., `TeamHuddleSection`).
+
+### HTML Content Rendering
+
+*   The `flutter_html` package is used within `ArticleDetailScreen` to render article content strings containing HTML tags (`<p>`, `<div>`, `<a>`, etc.).
+*   Styling is applied via the `Html` widget's `style` parameter to match the app's theme.
+*   Links within the HTML content are made tappable using `onLinkTap` and `url_launcher`.
+
+### Sharing
+
+*   The `share_plus` package is used to trigger the native OS sharing UI.
+*   A share action button is conditionally displayed in the `GlobalAppBar` (managed by `MainNavigationWrapper`) when viewing an article detail.
+*   The button reads the current article's data (headline, URL) and uses `Share.share()` to initiate the sharing process.
 
 ## Implemented Features
 
-*   **Core Setup:** Flutter project targeting iOS, Android, Web with VS Code integration.
-*   **Supabase Integration:** Initialization with secure credential loading (`.env`).
-*   **Global Theme:** Consistent app styling based on the provided style sheet.
-*   **Adaptive Navigation:** Bottom navigation bar (mobile) / Drawer (desktop/web).
-*   **Language Selection:** Global language picker (EN/DE) with device locale detection and preference persistence.
+*   **Core Setup:** Flutter project targeting iOS, Android, Web.
+*   **Supabase Integration:** Initialization, secure credential loading, Edge Function interaction via Services.
+*   **Global Theme:** Consistent app styling.
+*   **Adaptive Navigation (State-Driven):**
+    *   Persistent `GlobalAppBar`.
+    *   Bottom navigation bar (mobile) / Drawer (desktop/web) for main sections.
+    *   Article detail view shown *inline* within the main layout, controlled by Riverpod state.
+    *   Inline back button for detail view navigation.
+*   **Language Selection:** Global language picker (EN/DE) with persistence.
 *   **News Feed (`NewsFeedScreen`):**
-    *   Displays a list of news articles fetched from the `articlePreviews` Edge Function.
-    *   Includes Pull-to-Refresh.
-    *   Implements "Load Older" functionality (switches from 'NEW' only to 'All').
-    *   Includes infinite scrolling pagination when viewing 'All' articles.
-    *   Displays a prominent headline story (overall latest or team-specific latest).
-    *   Conditionally displays a "Team Huddle" section if a team is selected.
-*   **Team Huddle Section:**
-    *   Shows team logo and "Team Huddle" title.
-    *   Includes the team-specific headline story.
-    *   Includes expandable placeholder cards for "Upcoming Games" and "Injury Report".
-*   **My Team (`MyTeamScreen`):**
-    *   Allows users to select a favorite team via a dropdown.
-    *   Selection is saved locally using `shared_preferences`.
-    *   Displays articles filtered for the selected team (currently using the same preview service, needs dedicated data/service later).
+    *   Displays list of news article previews from `articlePreviews` Edge Function.
+    *   Pull-to-Refresh.
+    *   "Load Older" functionality & infinite scrolling pagination.
+    *   Prominent headline story (overall or team-specific).
+    *   Conditional "Team Huddle" section.
+*   **Team Huddle Section:** Displays team logo, team headline, placeholders for games/injuries.
+*   **My Team (`MyTeamScreen`):** Allows selection and persistence of a favorite team.
+*   **Article Detail (`ArticleDetailScreen`):**
+    *   Fetches full article data from `articleDetail` Edge Function based on ID.
+    *   Displays image (with fallback: Image1 > Image2 > Image3), headline, source, date.
+    *   Renders HTML content using `flutter_html` with theme styling.
+    *   Provides a tappable link to the original source article using `url_launcher`.
+    *   Includes Refresh and Share actions in the persistent `GlobalAppBar`.
+    *   Handles loading and error states gracefully.
 *   **Placeholder Screens:** Basic screens for Schedule and More.
 
 ## Running the App
 
 1.  Ensure you have completed the [Getting Started](#getting-started) steps.
-2.  Select your target device/platform in VS Code (bottom-right status bar) or list devices using `flutter devices`.
+2.  Select your target device/platform in VS Code or using `flutter devices`.
 3.  Start debugging:
     *   Press `F5` in VS Code.
-    *   Or run `flutter run -d <device_id>` in the terminal (e.g., `flutter run -d chrome`, `flutter run -d macos`, `flutter run -d <your_emulator_id>`).
+    *   Or run `flutter run -d <device_id>` (e.g., `flutter run -d chrome`).
 
 ## Backend Notes
 
-*   This Flutter app relies on a **Supabase backend**.
-*   Data fetching primarily uses **Edge Functions** written in TypeScript/Deno. These functions *must* be deployed and accessible.
-*   **RLS policies** are configured in Supabase to control data access based on user roles (`public`, `authenticated`). Edge functions respect these via the client's Authorization header.
-*   **Python scripts** handle backend data processing (scraping, cleaning, embedding, classification, etc.) and use the **Service Role Key** to interact with Supabase, bypassing RLS. These scripts run separately from the Flutter app.
+*   Relies on a **Supabase backend** with deployed **Edge Functions** (`articlePreviews`, `articleDetail`).
+*   **RLS policies** in Supabase control data access.
+*   **Python scripts** (run separately) handle backend data processing using the Service Role Key.
 
 ## Potential Next Steps
 
-*   Implement the `ArticleDetailScreen` to fetch and display full article content.
 *   Implement the `Schedule` and `More` screens.
-*   Implement real-time updates using Supabase Realtime.
-*   Connect `UpcomingGamesCard` and `InjuryReportCard` to real data sources/Edge Functions.
-*   Refine error handling and user feedback.
-*   Implement unit and widget tests.
-*   Optimize performance (e.g., image loading, build times).
-*   Add dark mode theme.
-*   Refactor `teamLogoMap` and `teamFullNameMap` into a more robust data source (e.g., fetched from `Teams` table).
+*   Implement real user authentication (Supabase Auth) and integrate it with RLS/providers.
+*   Connect `UpcomingGamesCard` and `InjuryReportCard` to real data.
+*   Refine error handling and user feedback across the app.
+*   Add unit, widget, and integration tests.
+*   Optimize performance further (image caching, build times, minimize widget rebuilds).
+*   Implement a dark mode theme.
+*   Refactor `teamLogoMap` and `teamFullNameMap` into a more robust data source (e.g., fetched from a `Teams` table in Supabase).
+*   Complete platform-specific sharing logic if needed (e.g., providing different formats).

--- a/lib/core/navigation/app_navigation.dart
+++ b/lib/core/navigation/app_navigation.dart
@@ -1,17 +1,22 @@
+// lib/core/navigation/app_navigation.dart
 import 'package:flutter/material.dart';
 import 'package:tackle_4_loss/core/navigation/nav_item.dart';
+// --- Make sure these imports match your file structure ---
 import 'package:tackle_4_loss/features/news_feed/ui/news_feed_screen.dart';
 import 'package:tackle_4_loss/features/my_team/ui/my_team_screen.dart';
 import 'package:tackle_4_loss/features/schedule/ui/schedule_screen.dart';
 import 'package:tackle_4_loss/features/more/ui/more_screen.dart';
+// --- End Imports ---
 
+// Keep the list final, but remove const from the NavItem instances inside
 final List<NavItem> appNavItems = [
-  const NavItem(label: 'News', icon: Icons.newspaper, screen: NewsFeedScreen()),
-  const NavItem(label: 'My Team', icon: Icons.people, screen: MyTeamScreen()),
-  const NavItem(
+  // Removed 'const' from each NavItem because NewsFeedScreen is not const
+  NavItem(label: 'News', icon: Icons.newspaper, screen: NewsFeedScreen()),
+  NavItem(label: 'My Team', icon: Icons.people, screen: MyTeamScreen()),
+  NavItem(
     label: 'Schedule',
     icon: Icons.calendar_month,
     screen: ScheduleScreen(),
   ),
-  const NavItem(label: 'More', icon: Icons.more_horiz, screen: MoreScreen()),
+  NavItem(label: 'More', icon: Icons.more_horiz, screen: MoreScreen()),
 ];

--- a/lib/core/providers/navigation_provider.dart
+++ b/lib/core/providers/navigation_provider.dart
@@ -1,9 +1,15 @@
+// lib/core/providers/navigation_provider.dart
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// Holds the currently selected navigation index
+// Holds the currently selected navigation index for the main sections (News, Team, etc.)
 final selectedNavIndexProvider = StateProvider<int>((ref) => 0);
 
-// Holds the state of the sidebar (expanded or collapsed) for non-mobile layouts
-final isSidebarExtendedProvider = StateProvider<bool>(
-  (ref) => false,
-); // Start collapsed
+// --- NEW: Holds the ID of the article currently being viewed in detail ---
+// Null means no detail screen is shown, displaying the main IndexedStack content.
+final currentDetailArticleIdProvider = StateProvider<int?>((ref) => null);
+
+
+// Holds the state of the sidebar (expanded or collapsed) for non-mobile layouts - REMOVED as it wasn't used per README.md
+// final isSidebarExtendedProvider = StateProvider<bool>(
+//   (ref) => false,
+// ); // Start collapsed

--- a/lib/features/article_detail/data/article_detail.dart
+++ b/lib/features/article_detail/data/article_detail.dart
@@ -1,0 +1,120 @@
+// lib/features/article_detail/data/article_detail.dart
+import 'package:flutter/foundation.dart';
+
+@immutable
+class ArticleDetail {
+  final int id;
+  final String englishHeadline;
+  final String germanHeadline;
+  final String? contentEnglish; // Nullable if can be empty
+  final String? contentGerman; // Nullable if can be empty
+  final String? image1;
+  final String? image2;
+  final String? image3;
+  final DateTime? createdAt; // Use DateTime for easier handling
+  final String? sourceUrl;
+  final String? sourceName;
+  final String? teamId;
+  final String? status;
+  // final String? updatedBy; // Add if needed
+
+  const ArticleDetail({
+    required this.id,
+    required this.englishHeadline,
+    required this.germanHeadline,
+    this.contentEnglish,
+    this.contentGerman,
+    this.image1,
+    this.image2,
+    this.image3,
+    this.createdAt,
+    this.sourceUrl,
+    this.sourceName,
+    this.teamId,
+    this.status,
+    // this.updatedBy,
+  });
+
+  factory ArticleDetail.fromJson(Map<String, dynamic> json) {
+    DateTime? parsedDate;
+    if (json['createdAt'] != null && json['createdAt'] is String) {
+      try {
+        parsedDate = DateTime.tryParse(json['createdAt']);
+      } catch (e) {
+        debugPrint("Error parsing date: ${json['createdAt']} - $e");
+      }
+    }
+
+    // Helper to safely get string values, returning null if empty or not string
+    String? getStringOrNull(dynamic value) {
+      if (value is String && value.isNotEmpty) {
+        return value;
+      }
+      return null;
+    }
+
+    return ArticleDetail(
+      id: json['id'] as int? ?? 0, // Provide default or handle error
+      englishHeadline: json['englishHeadline'] as String? ?? '',
+      germanHeadline: json['germanHeadline'] as String? ?? '',
+      contentEnglish: getStringOrNull(json['ContentEnglish']),
+      contentGerman: getStringOrNull(json['ContentGerman']),
+      image1: getStringOrNull(json['Image1']),
+      image2: getStringOrNull(json['Image2']),
+      image3: getStringOrNull(json['Image3']),
+      createdAt: parsedDate,
+      sourceUrl: getStringOrNull(json['sourceUrl']),
+      sourceName: getStringOrNull(json['SourceName']),
+      teamId: getStringOrNull(json['teamId']),
+      status: getStringOrNull(json['status']),
+      // updatedBy: getStringOrNull(json['UpdatedBy']),
+    );
+  }
+
+  // Optional: Helper to get localized headline
+  String getLocalizedHeadline(String languageCode) {
+    if (languageCode == 'de' && germanHeadline.isNotEmpty) {
+      return germanHeadline;
+    }
+    return englishHeadline.isNotEmpty ? englishHeadline : "No Title";
+  }
+
+  // Optional: Helper to get localized content
+  String? getLocalizedContent(String languageCode) {
+    if (languageCode == 'de' && contentGerman != null) {
+      return contentGerman;
+    }
+    // Fallback to English if German is null or language is not German
+    return contentEnglish;
+  }
+
+  // --- NEW: Helper to get the primary image URL with fallback ---
+  String? get primaryImageUrl {
+    if (image1 != null && image1!.isNotEmpty) {
+      return image1;
+    }
+    if (image2 != null && image2!.isNotEmpty) {
+      return image2;
+    }
+    if (image3 != null && image3!.isNotEmpty) {
+      return image3;
+    }
+    return null; // No valid image found
+  }
+  // --- End New Helper ---
+
+  // Keep this if needed elsewhere, but primaryImageUrl is preferred for the detail view
+  List<String> get validImageUrls {
+    return [image1, image2, image3].whereType<String>().toList();
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ArticleDetail &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/features/article_detail/data/article_detail_service.dart
+++ b/lib/features/article_detail/data/article_detail_service.dart
@@ -1,0 +1,70 @@
+// lib/features/article_detail/data/article_detail_service.dart
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:tackle_4_loss/features/article_detail/data/article_detail.dart';
+
+class ArticleDetailService {
+  final SupabaseClient _supabaseClient;
+
+  ArticleDetailService({SupabaseClient? supabaseClient})
+    : _supabaseClient = supabaseClient ?? Supabase.instance.client;
+
+  Future<ArticleDetail> getArticleDetail(int articleId) async {
+    try {
+      final functionName = 'articleDetail';
+      final parameters = {
+        'id': articleId.toString(), // Pass articleId as query parameter
+      };
+
+      debugPrint("Fetching article detail for ID: $articleId");
+
+      final response = await _supabaseClient.functions.invoke(
+        functionName,
+        method: HttpMethod.get, // Assuming GET method
+        queryParameters: parameters,
+      );
+
+      if (response.status != 200) {
+        var errorData = response.data;
+        String errorMessage = 'Status code ${response.status}';
+        if (errorData is Map && errorData.containsKey('error')) {
+          errorMessage += ': ${errorData['error']}';
+        } else if (errorData != null) {
+          errorMessage += ': ${errorData.toString().substring(0, 100)}...';
+        }
+        debugPrint('Error response data: $errorData');
+        throw Exception('Failed to load article detail: $errorMessage');
+      }
+
+      if (response.data == null) {
+        throw Exception(
+          'Failed to load article detail: Received null data from function.',
+        );
+      }
+
+      final responseData = response.data as Map<String, dynamic>;
+
+      // Check if the function itself returned an error structure
+      if (responseData.containsKey('error')) {
+        throw Exception('Error from Edge Function: ${responseData['error']}');
+      }
+      // Optionally check if the expected data field exists if your function wraps data
+      // final articleData = responseData['data'] as Map<String, dynamic>? ?? responseData;
+
+      final article = ArticleDetail.fromJson(
+        responseData,
+      ); // Use responseData directly if not wrapped
+      debugPrint("Successfully fetched article detail for ID: $articleId");
+      return article;
+    } on FunctionException catch (e) {
+      debugPrint('Supabase FunctionException Details: ${e.details}');
+      debugPrint('Supabase FunctionException toString(): ${e.toString()}');
+      final errorMessage = e.details?.toString() ?? e.toString();
+      throw Exception('Error fetching article detail: $errorMessage');
+    } catch (e, stacktrace) {
+      debugPrint('Generic error fetching article detail: $e');
+      debugPrint('Stacktrace: $stacktrace');
+      throw Exception('An unexpected error occurred fetching the article.');
+    }
+  }
+}

--- a/lib/features/article_detail/logic/article_detail_provider.dart
+++ b/lib/features/article_detail/logic/article_detail_provider.dart
@@ -1,0 +1,20 @@
+// lib/features/article_detail/logic/article_detail_provider.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tackle_4_loss/features/article_detail/data/article_detail.dart';
+import 'package:tackle_4_loss/features/article_detail/data/article_detail_service.dart';
+
+// Provider for the service instance
+final articleDetailServiceProvider = Provider<ArticleDetailService>((ref) {
+  return ArticleDetailService();
+});
+
+// FutureProvider.family to fetch details for a specific article ID
+final articleDetailProvider = FutureProvider.family<ArticleDetail, int>((
+  ref,
+  articleId,
+) async {
+  // Get the service
+  final service = ref.watch(articleDetailServiceProvider);
+  // Fetch the data
+  return service.getArticleDetail(articleId);
+});

--- a/lib/features/article_detail/ui/article_detail_screen.dart
+++ b/lib/features/article_detail/ui/article_detail_screen.dart
@@ -1,34 +1,251 @@
 // lib/features/article_detail/ui/article_detail_screen.dart
 import 'package:flutter/material.dart';
-import 'package:tackle_4_loss/core/widgets/global_app_bar.dart'; // Import global AppBar
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_html/flutter_html.dart';
 
-class ArticleDetailScreen extends StatelessWidget {
-  final int articleId; // Example: pass the ID of the article to show
+// Removed GlobalAppBar import as it's no longer used here
+import 'package:tackle_4_loss/core/widgets/loading_indicator.dart';
+import 'package:tackle_4_loss/core/widgets/error_message.dart';
+import 'package:tackle_4_loss/core/providers/locale_provider.dart';
+import 'package:tackle_4_loss/features/article_detail/logic/article_detail_provider.dart';
+// Import navigation provider to trigger back navigation state change
+import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
+// Removed kMaxContentWidth import, handled by MainNavigationWrapper
+
+class ArticleDetailScreen extends ConsumerWidget {
+  final int articleId;
 
   const ArticleDetailScreen({super.key, required this.articleId});
 
+  // _launchUrl remains the same, accepting ref
+  Future<void> _launchUrl(Uri url, BuildContext context, WidgetRef ref) async {
+    final articleValue = ref.read(articleDetailProvider(articleId)).valueOrNull;
+    final sourceDomain =
+        articleValue?.sourceUrl != null
+            ? Uri.parse(articleValue!.sourceUrl!).host
+            : null;
+    final targetDomain = url.host;
+
+    if (sourceDomain != null && targetDomain == sourceDomain) {
+      debugPrint("Attempted to open internal link: $url. Opening externally.");
+    }
+
+    if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Could not launch $url')));
+      }
+    }
+  }
+
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      // Use the GlobalAppBar here as well
-      appBar: GlobalAppBar(
-        // This screen is not the root, so automaticallyImplyLeading defaults to true
-        // which will show the back button. That's usually what we want.
+  Widget build(BuildContext context, WidgetRef ref) {
+    final articleAsyncValue = ref.watch(articleDetailProvider(articleId));
+    final currentLocale = ref.watch(localeNotifierProvider);
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
 
-        // Example: Override title if needed
-        // title: Text('Article Detail'),
+    // --- NO Scaffold or AppBar here ---
 
-        // Example: Add screen-specific actions
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.share_outlined),
-            onPressed: () {
-              debugPrint('Share article $articleId');
-            },
+    // Use a simple Container or Padding as the root if needed,
+    // otherwise the direct content widget is fine.
+    return articleAsyncValue.when(
+      loading: () => const LoadingIndicator(),
+      error:
+          (error, stackTrace) => Padding(
+            // Add padding around error msg
+            padding: const EdgeInsets.all(16.0),
+            child: ErrorMessageWidget(
+              message: 'Failed to load article details.\n${error.toString()}',
+              // Retry still invalidates the provider
+              onRetry: () => ref.invalidate(articleDetailProvider(articleId)),
+            ),
           ),
-        ],
-      ),
-      body: Center(child: Text('Showing details for Article ID: $articleId')),
+      data: (article) {
+        final localeCode = currentLocale.languageCode;
+        final headline = article.getLocalizedHeadline(localeCode);
+        final htmlContent = article.getLocalizedContent(localeCode);
+        final primaryImageUrl = article.primaryImageUrl;
+        final sourceUri =
+            article.sourceUrl != null ? Uri.tryParse(article.sourceUrl!) : null;
+
+        // --- Content is wrapped in SingleChildScrollView ---
+        // The Center and ConstrainedBox are now handled by MainNavigationWrapper
+        return SingleChildScrollView(
+          // Add padding here for the content area
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // --- NEW: Back Button ---
+              Padding(
+                padding: const EdgeInsets.only(
+                  bottom: 12.0,
+                ), // Space below button
+                child: TextButton.icon(
+                  icon: const Icon(Icons.arrow_back_ios, size: 16),
+                  label: const Text('Back to News'), // Or just 'Back'
+                  style: TextButton.styleFrom(
+                    // Visual density compact to make it less intrusive
+                    visualDensity: VisualDensity.compact,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                  ),
+                  onPressed: () {
+                    // Set the detail ID back to null to navigate away
+                    ref.read(currentDetailArticleIdProvider.notifier).state =
+                        null;
+                  },
+                ),
+              ),
+              // --- End Back Button ---
+
+              // 1. Primary Image
+              if (primaryImageUrl != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16.0),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12.0),
+                    child: CachedNetworkImage(
+                      imageUrl: primaryImageUrl,
+                      fit: BoxFit.cover,
+                      width: double.infinity,
+                      placeholder:
+                          (context, url) => Container(
+                            height: 250,
+                            color: Colors.grey[200],
+                            child: const Center(child: LoadingIndicator()),
+                          ),
+                      errorWidget:
+                          (context, url, error) => Container(
+                            height: 250,
+                            color: Colors.grey[200],
+                            child: Icon(
+                              Icons.broken_image_outlined,
+                              color: Colors.grey[500],
+                              size: 40,
+                            ),
+                          ),
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 8),
+
+              // 2. Headline
+              Text(headline, style: textTheme.headlineMedium),
+              const SizedBox(height: 8),
+
+              // 3. Source & Date Row
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Flexible(
+                    child: Text(
+                      article.sourceName ?? 'Unknown Source',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: Colors.grey[600],
+                        fontStyle: FontStyle.italic,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  if (article.createdAt != null)
+                    Text(
+                      DateFormat.yMMMd(localeCode).format(article.createdAt!),
+                      style: textTheme.bodySmall?.copyWith(
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              const Divider(),
+              const SizedBox(height: 16),
+
+              // 4. Content
+              if (htmlContent != null && htmlContent.isNotEmpty)
+                Html(
+                  data: htmlContent,
+                  style: {
+                    "body": Style(
+                      fontSize: FontSize(textTheme.bodyLarge?.fontSize ?? 16.0),
+                      color: textTheme.bodyLarge?.color,
+                      lineHeight: LineHeight(
+                        textTheme.bodyLarge?.height ?? 1.5,
+                      ),
+                      margin: Margins.zero,
+                      padding: HtmlPaddings.zero,
+                    ),
+                    "p": Style(margin: Margins.only(bottom: 12.0)),
+                    "a": Style(
+                      color: theme.colorScheme.primary,
+                      textDecoration: TextDecoration.underline,
+                    ),
+                    "h1": Style(
+                      fontSize: FontSize(
+                        textTheme.headlineSmall?.fontSize ?? 20.0,
+                      ),
+                      fontWeight: textTheme.headlineSmall?.fontWeight,
+                      margin: Margins.symmetric(vertical: 10.0),
+                    ),
+                    "h2": Style(
+                      fontSize: FontSize(
+                        textTheme.titleLarge?.fontSize ?? 18.0,
+                      ),
+                      fontWeight: textTheme.titleLarge?.fontWeight,
+                      margin: Margins.symmetric(vertical: 8.0),
+                    ),
+                  },
+                  onLinkTap: (url, attributes, element) {
+                    if (url != null) {
+                      final uri = Uri.tryParse(url);
+                      if (uri != null) {
+                        _launchUrl(uri, context, ref);
+                      } else {
+                        debugPrint("Could not parse URL from HTML link: $url");
+                      }
+                    }
+                  },
+                )
+              else
+                Text(
+                  'Article content is not available.',
+                  style: textTheme.bodyLarge?.copyWith(
+                    fontStyle: FontStyle.italic,
+                    color: Colors.grey[600],
+                  ),
+                ),
+              const SizedBox(height: 24),
+
+              // 5. Source Link Button
+              if (sourceUri != null && article.sourceUrl != null)
+                Center(
+                  child: TextButton.icon(
+                    icon: const Icon(Icons.open_in_browser, size: 18),
+                    label: Text(
+                      'Read Full Article at ${article.sourceName ?? 'Source'}',
+                    ),
+                    onPressed: () => _launchUrl(sourceUri, context, ref),
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 10,
+                      ),
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 20),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/news_feed/ui/widgets/article_list_item.dart
+++ b/lib/features/news_feed/ui/widgets/article_list_item.dart
@@ -1,15 +1,15 @@
 // lib/features/news_feed/ui/widgets/article_list_item.dart
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Import Riverpod
-import 'package:tackle_4_loss/core/providers/locale_provider.dart'; // Import locale provider
-import 'package:cached_network_image/cached_network_image.dart'; // For optimized image loading
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tackle_4_loss/core/providers/locale_provider.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
-import 'package:intl/intl.dart'; // For date formatting
-import 'package:tackle_4_loss/core/theme/app_colors.dart'; // Import your app colors
-// Import your placeholder detail screen (or the actual one later)
-import 'package:tackle_4_loss/features/article_detail/ui/article_detail_screen.dart';
+import 'package:intl/intl.dart';
+import 'package:tackle_4_loss/core/theme/app_colors.dart';
+// Removed import for ArticleDetailScreen
+// Import navigation provider to update detail state
+import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
 
-// Make it a ConsumerWidget to access ref
 class ArticleListItem extends ConsumerWidget {
   final ArticlePreview article;
 
@@ -17,46 +17,31 @@ class ArticleListItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Add WidgetRef ref
-    // Get theme data
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final chipTheme = theme.chipTheme;
-    // Watch the current locale provider
     final currentLocale = ref.watch(localeNotifierProvider);
 
-    // Determine which headline to show based on locale
-    // Provide fallbacks if one language headline is empty
     final headlineToShow =
         (currentLocale.languageCode == 'de' &&
                 article.germanHeadline.isNotEmpty)
             ? article.germanHeadline
             : (article.englishHeadline.isNotEmpty
                 ? article.englishHeadline
-                : "No Title"); // Fallback to English or "No Title"
+                : "No Title");
 
     return Card(
-      // Card uses theme's cardTheme implicitly
-      // Removed margin here, assuming handled by CardTheme or parent padding
       child: InkWell(
         onTap: () {
-          // Navigate to the detail screen
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              // Pass the article ID to the detail screen
-              builder: (context) => ArticleDetailScreen(articleId: article.id),
-            ),
-          );
-          // Removed print statement
+          // --- MODIFIED: Update detail state instead of Navigator.push ---
+          ref.read(currentDetailArticleIdProvider.notifier).state = article.id;
+          // --- End Modification ---
         },
-        borderRadius: BorderRadius.circular(
-          12.0,
-        ), // Match Card shape for InkWell ripple
+        borderRadius: BorderRadius.circular(12.0),
         child: Padding(
-          padding: const EdgeInsets.all(12.0), // Consistent padding
+          padding: const EdgeInsets.all(12.0),
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start, // Align items to top
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // Image Section
               SizedBox(
@@ -80,12 +65,10 @@ class ArticleListItem extends ConsumerWidget {
                                     color: Colors.grey[500],
                                   ),
                                 ),
-                            // Cache size hint (adjust based on actual display)
                             memCacheHeight: 180,
                             memCacheWidth: 180,
                           )
                           : Container(
-                            // Placeholder if no image URL
                             decoration: BoxDecoration(
                               color: Colors.grey[200],
                               borderRadius: BorderRadius.circular(8.0),
@@ -103,39 +86,30 @@ class ArticleListItem extends ConsumerWidget {
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment:
-                      MainAxisAlignment
-                          .spaceBetween, // Distribute vertical space
-                  // Ensure Column takes up the height of the Row (important with Row's crossAxisAlignment.start)
-                  mainAxisSize:
-                      MainAxisSize
-                          .min, // Take minimum space needed unless expanded
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      headlineToShow, // Use the selected headline
-                      style:
-                          textTheme.titleSmall, // Using titleSmall from theme
-                      maxLines: 3, // Allow up to 3 lines
+                      headlineToShow,
+                      style: textTheme.titleSmall,
+                      maxLines: 3,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    const SizedBox(height: 6), // Spacing
+                    const SizedBox(height: 6),
                     Column(
-                      // Group bottom row elements
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         if (article.createdAt != null)
                           Text(
-                            // Pass the locale string to DateFormat
                             DateFormat.yMMMd(
                               currentLocale.toString(),
                             ).add_jm().format(article.createdAt!),
-                            style: textTheme.bodySmall, // Use theme style
+                            style: textTheme.bodySmall,
                           ),
                         const SizedBox(height: 8),
                         Wrap(
-                          // Use Wrap for chips
-                          spacing: 6.0, // Horizontal space between chips
-                          runSpacing: 4.0, // Vertical space if chips wrap
+                          spacing: 6.0,
+                          runSpacing: 4.0,
                           children: [
                             if (article.teamId != null &&
                                 article.teamId!.isNotEmpty)
@@ -150,9 +124,7 @@ class ArticleListItem extends ConsumerWidget {
                                 visualDensity: VisualDensity.compact,
                                 materialTapTargetSize:
                                     MaterialTapTargetSize.shrinkWrap,
-                                backgroundColor:
-                                    chipTheme
-                                        .backgroundColor, // Use theme background
+                                backgroundColor: chipTheme.backgroundColor,
                               ),
                             Chip(
                               label: Text(article.status.toUpperCase()),
@@ -161,9 +133,7 @@ class ArticleListItem extends ConsumerWidget {
                                   chipTheme.labelPadding ??
                                   const EdgeInsets.symmetric(horizontal: 4),
                               labelStyle: chipTheme.labelStyle?.copyWith(
-                                color:
-                                    AppColors
-                                        .white, // Ensure white text on colored chip
+                                color: AppColors.white,
                                 fontSize: 10,
                                 fontWeight: FontWeight.bold,
                               ),
@@ -185,19 +155,17 @@ class ArticleListItem extends ConsumerWidget {
     );
   }
 
-  // Helper function to determine status chip color
   Color _getStatusColor(String? status) {
     switch (status?.toUpperCase()) {
-      // Use uppercase for case-insensitive matching
       case 'NEW':
         return Colors.green.shade600;
       case 'UPDATE':
         return Colors.orange.shade700;
-      case 'PUBLISHED': // Assuming 'PUBLISHED' is a possible status
-        return AppColors.primaryGreen; // Use your primary theme color
+      case 'PUBLISHED':
+        return AppColors.primaryGreen;
       case 'OLD':
         return Colors.grey.shade600;
-      default: // Default color for unknown statuses
+      default:
         return Colors.grey.shade600;
     }
   }

--- a/lib/features/news_feed/ui/widgets/headline_story_card.dart
+++ b/lib/features/news_feed/ui/widgets/headline_story_card.dart
@@ -5,8 +5,9 @@ import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
 import 'package:tackle_4_loss/core/theme/app_colors.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tackle_4_loss/core/providers/locale_provider.dart';
-// Import detail screen for navigation (ensure path is correct)
-import 'package:tackle_4_loss/features/article_detail/ui/article_detail_screen.dart';
+// Removed import for ArticleDetailScreen
+// Import navigation provider to update detail state
+import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
 
 class HeadlineStoryCard extends ConsumerWidget {
   final ArticlePreview article;
@@ -23,13 +24,12 @@ class HeadlineStoryCard extends ConsumerWidget {
             ? article.germanHeadline
             : article.englishHeadline;
 
-    // Fallback logic for headline display
     final displayHeadline =
         headlineToShow.isNotEmpty
             ? headlineToShow
             : (article.englishHeadline.isNotEmpty
                 ? article.englishHeadline
-                : "Headline Unavailable"); // Final fallback
+                : "Headline Unavailable");
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 8.0),
@@ -40,23 +40,17 @@ class HeadlineStoryCard extends ConsumerWidget {
           borderRadius: BorderRadius.circular(16.0),
         ),
         elevation: 4.0,
-        shadowColor: Colors.black.withAlpha(
-          (255 * 0.2).round(),
-        ), // Use withAlpha instead
+        shadowColor: Colors.black.withAlpha((255 * 0.2).round()),
         child: InkWell(
           onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder:
-                    (context) => ArticleDetailScreen(articleId: article.id),
-              ),
-            );
+            // --- MODIFIED: Update detail state instead of Navigator.push ---
+            ref.read(currentDetailArticleIdProvider.notifier).state =
+                article.id;
+            // --- End Modification ---
           },
           child: Stack(
             alignment: Alignment.bottomLeft,
             children: [
-              // 1. Background Image
               AspectRatio(
                 aspectRatio: 16 / 9,
                 child:
@@ -82,19 +76,13 @@ class HeadlineStoryCard extends ConsumerWidget {
                           ),
                         ),
               ),
-
-              // 2. Gradient Overlay
               Positioned.fill(
                 child: Container(
                   decoration: BoxDecoration(
                     gradient: LinearGradient(
                       colors: [
-                        Colors.black.withAlpha(
-                          (255 * 0.0).round(),
-                        ), // Use withAlpha
-                        Colors.black.withAlpha(
-                          (255 * 0.7).round(),
-                        ), // Use withAlpha
+                        Colors.black.withAlpha((255 * 0.0).round()),
+                        Colors.black.withAlpha((255 * 0.7).round()),
                       ],
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,
@@ -103,24 +91,19 @@ class HeadlineStoryCard extends ConsumerWidget {
                   ),
                 ),
               ),
-
-              // 3. Headline Text
               Positioned(
-                // Use Positioned instead of Padding for better control with Stack
                 bottom: 16.0,
                 left: 16.0,
-                right: 16.0, // Constrain width
+                right: 16.0,
                 child: Text(
-                  displayHeadline, // Use the variable with fallback logic
+                  displayHeadline,
                   style: textTheme.titleLarge?.copyWith(
                     color: AppColors.white,
                     fontWeight: FontWeight.bold,
                     shadows: [
                       Shadow(
                         blurRadius: 4.0,
-                        color: Colors.black.withAlpha(
-                          (255 * 0.5).round(),
-                        ), // Use withAlpha
+                        color: Colors.black.withAlpha((255 * 0.5).round()),
                         offset: const Offset(1.0, 1.0),
                       ),
                     ],

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import app_links
 import path_provider_foundation
+import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
 import url_launcher_macos
@@ -14,6 +15,7 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -129,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -190,8 +206,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.1"
+  flutter_html:
+    dependency: "direct main"
+    description:
+      name: flutter_html
+      sha256: "38a2fd702ffdf3243fb7441ab58aa1bc7e6922d95a50db76534de8260638558d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_lints:
-    dependency: "direct dev"
+    dependency: "direct overridden"
     description:
       name: flutter_lints
       sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
@@ -245,6 +269,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "9475be233c437f0e3637af55e7702cbbe5c23a68bd56e8a5fa2d426297b7c6c8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.5+1"
   http:
     dependency: transitive
     description:
@@ -325,6 +357,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  list_counter:
+    dependency: transitive
+    description:
+      name: list_counter
+      sha256: c447ae3dfcd1c55f0152867090e67e219d42fe6d4f2807db4bbe8b8d69912237
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   logging:
     dependency: transitive
     description:
@@ -493,6 +533,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -699,7 +755,7 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
@@ -787,7 +843,7 @@ packages:
     source: hosted
     version: "14.3.1"
   web:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
@@ -810,6 +866,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.12.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,10 +44,16 @@ dependencies:
   intl: ^0.19.0
   shared_preferences: ^2.5.3
   country_flags: ^3.0.0
+  url_launcher: ^6.3.0
+  flutter_html: ^3.0.0
+  share_plus: ^10.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+dependency_overrides:
+  web: ^1.0.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  share_plus
   url_launcher_windows
 )
 


### PR DESCRIPTION
- Introduced `currentDetailArticleIdProvider` to manage the currently viewed article ID.
- Updated `ArticleDetailScreen` to use Riverpod for state management instead of direct navigation.
- Modified `ArticleListItem` and `HeadlineStoryCard` to update the article ID in the provider on tap.
- Removed unused imports and code related to direct navigation to `ArticleDetailScreen`.
- Added `ArticleDetail` model and service for fetching article details from Supabase.
- Implemented error handling and data parsing in `ArticleDetailService`.
- Updated dependencies in `pubspec.yaml` for `flutter_html` and `share_plus`.
- Registered new plugins in macOS and Windows for share functionality.