### PR TITLE
Add Teams feature with data fetching and UI representation

### DIFF
--- a/lib/core/constants/layout_constants.dart
+++ b/lib/core/constants/layout_constants.dart
@@ -1,0 +1,2 @@
+const double kMaxContentWidth = 1200.0;
+const double kMobileLayoutBreakpoint = 720.0;

--- a/lib/core/constants/team_constants.dart
+++ b/lib/core/constants/team_constants.dart
@@ -1,4 +1,6 @@
 final Map<String, String> teamLogoMap = {
+  'AFC': 'afc',
+  'NFC': 'nfc',
   'ARI': 'arizona_cardinals',
   'ATL': 'atlanta_falcons',
   'BAL': 'baltimore_ravens',
@@ -37,6 +39,8 @@ final Map<String, String> teamLogoMap = {
 
 // --- Map for Full Team Names ---
 final Map<String, String> teamFullNameMap = {
+  'AFC': 'American Football Conference',
+  'NFC': 'National Football Conference',
   'ARI': 'Arizona Cardinals',
   'ATL': 'Atlanta Falcons',
   'BAL': 'Baltimore Ravens',

--- a/lib/features/more/ui/more_options_sheet_content.dart
+++ b/lib/features/more/ui/more_options_sheet_content.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tackle_4_loss/features/all_news/ui/all_news_screen.dart';
-// --- Import the Settings Screen ---
 import 'package:tackle_4_loss/features/settings/ui/settings_screen.dart';
+// --- Import the new Teams Screen ---
+import 'package:tackle_4_loss/features/teams/ui/teams_screen.dart';
 // import 'package:url_launcher/url_launcher.dart'; // Keep commented for now
 
 class MoreOptionsSheetContent extends ConsumerWidget {
@@ -83,15 +84,16 @@ class MoreOptionsSheetContent extends ConsumerWidget {
           ),
           _buildMoreListItem(
             context: context,
-            icon: Icons.group,
+            icon: Icons.group, // Using 'group' icon for Teams
             title: 'Teams',
             onTap: () {
-              debugPrint('Teams tapped');
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Navigate to Teams (Not Implemented)'),
-                ),
+              // --- MODIFIED: Navigate to TeamsScreen ---
+              debugPrint('Teams tapped - Navigating to TeamsScreen');
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const TeamsScreen()),
               );
+              // --- END MODIFICATION ---
             },
           ),
           _buildMoreListItem(

--- a/lib/features/teams/data/team_info.dart
+++ b/lib/features/teams/data/team_info.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class TeamInfo {
+  final String teamId; // e.g., "BUF"
+  final String fullName; // e.g., "Buffalo Bills"
+  final String division; // e.g., "AFC East"
+  final String conference; // e.g., "AFC"
+
+  const TeamInfo({
+    required this.teamId,
+    required this.fullName,
+    required this.division,
+    required this.conference,
+  });
+
+  factory TeamInfo.fromJson(Map<String, dynamic> json) {
+    return TeamInfo(
+      teamId: json['teamId'] as String? ?? '',
+      fullName: json['fullName'] as String? ?? 'Unknown Team',
+      division: json['division'] as String? ?? 'Unknown Division',
+      conference: json['conference'] as String? ?? 'Unknown Conference',
+    );
+  }
+
+  // Optional: Add toJson, equality operators if needed
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TeamInfo &&
+          runtimeType == other.runtimeType &&
+          teamId == other.teamId;
+
+  @override
+  int get hashCode => teamId.hashCode;
+}

--- a/lib/features/teams/data/team_service.dart
+++ b/lib/features/teams/data/team_service.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:tackle_4_loss/features/teams/data/team_info.dart';
+
+class TeamService {
+  final SupabaseClient _supabaseClient;
+  static const _teamsFunctionName = 'teams'; // Name of your Edge Function
+
+  TeamService({SupabaseClient? supabaseClient})
+    : _supabaseClient = supabaseClient ?? Supabase.instance.client;
+
+  Future<List<TeamInfo>> fetchTeams() async {
+    debugPrint("Attempting to fetch teams from Edge Function...");
+    try {
+      final response = await _supabaseClient.functions.invoke(
+        _teamsFunctionName,
+        method: HttpMethod.get, // Assuming GET method for your function
+      );
+
+      if (response.status != 200) {
+        debugPrint(
+          "Error fetching teams: Status Code ${response.status}, Data: ${response.data}",
+        );
+        throw Exception('Failed to load teams: Status code ${response.status}');
+      }
+
+      if (response.data == null || response.data['data'] == null) {
+        debugPrint(
+          "Error fetching teams: Response data or 'data' key is null.",
+        );
+        throw Exception('Failed to load teams: Received invalid data format.');
+      }
+
+      // Expecting {"data": [...]} structure based on your description
+      final List<dynamic> teamListJson = response.data['data'] as List<dynamic>;
+
+      final List<TeamInfo> teams =
+          teamListJson
+              .map((json) {
+                try {
+                  return TeamInfo.fromJson(json as Map<String, dynamic>);
+                } catch (e) {
+                  debugPrint("Error parsing team JSON: $json - Error: $e");
+                  return null; // Handle parsing errors for individual items
+                }
+              })
+              .whereType<TeamInfo>()
+              .toList(); // Filter out nulls from parsing errors
+
+      debugPrint("Successfully fetched and parsed ${teams.length} teams.");
+      return teams;
+    } on FunctionException catch (e) {
+      // Log the details for debugging purposes
+      debugPrint('Supabase FunctionException fetching teams: ${e.details}');
+      // FIX: Use toString() instead of message for the re-thrown exception
+      throw Exception('Error invoking teams function: ${e.toString()}');
+    } catch (e, stacktrace) {
+      debugPrint('Generic error fetching teams: $e\n$stacktrace');
+      throw Exception('An unexpected error occurred fetching teams.');
+    }
+  }
+}

--- a/lib/features/teams/logic/teams_provider.dart
+++ b/lib/features/teams/logic/teams_provider.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tackle_4_loss/features/teams/data/team_info.dart';
+import 'package:tackle_4_loss/features/teams/data/team_service.dart';
+import 'package:collection/collection.dart'; // Import for groupBy
+
+// 1. Provider for the TeamService instance
+final teamServiceProvider = Provider<TeamService>((ref) {
+  return TeamService();
+});
+
+// 2. FutureProvider to fetch the raw list of teams
+final allTeamsProvider = FutureProvider<List<TeamInfo>>((ref) async {
+  final teamService = ref.watch(teamServiceProvider);
+  return teamService.fetchTeams();
+});
+
+// --- Grouping Logic ---
+
+// Helper class to structure grouped data for the UI
+class DivisionGroup {
+  final String divisionName; // e.g., "AFC East"
+  final List<TeamInfo> teams;
+
+  DivisionGroup({required this.divisionName, required this.teams});
+}
+
+class ConferenceGroup {
+  final String conferenceName; // e.g., "AFC"
+  final List<DivisionGroup> divisions; // Sorted list of divisions
+
+  ConferenceGroup({required this.conferenceName, required this.divisions});
+}
+
+// 3. Provider to group and sort the fetched teams
+final groupedTeamsProvider = Provider<AsyncValue<List<ConferenceGroup>>>((ref) {
+  // Watch the raw teams provider
+  final asyncTeams = ref.watch(allTeamsProvider);
+
+  // Transform the AsyncValue
+  return asyncTeams.when(
+    data: (teams) {
+      if (teams.isEmpty) {
+        return const AsyncData([]); // Return empty list if no teams fetched
+      }
+
+      // Define the desired order for divisions
+      const divisionOrder = ['East', 'North', 'South', 'West'];
+
+      // Group by Conference first
+      final groupedByConference = teams.groupListsBy((t) => t.conference);
+
+      final List<ConferenceGroup> conferenceGroups = [];
+
+      // Process AFC first, then NFC (or handle dynamic conferences)
+      for (final conferenceName in ['AFC', 'NFC']) {
+        if (groupedByConference.containsKey(conferenceName)) {
+          final conferenceTeams = groupedByConference[conferenceName]!;
+
+          // Group teams within the conference by Division
+          final groupedByDivision = conferenceTeams.groupListsBy(
+            (t) => t.division,
+          );
+
+          final List<DivisionGroup> divisionGroups = [];
+
+          // Sort divisions according to the defined order
+          final sortedDivisionNames = groupedByDivision.keys.sorted((a, b) {
+            // Extract the direction part (East, North, etc.)
+            String directionA = a.split(' ').last;
+            String directionB = b.split(' ').last;
+            int indexA = divisionOrder.indexOf(directionA);
+            int indexB = divisionOrder.indexOf(directionB);
+            // Handle cases where division might not be in the order (fallback)
+            if (indexA == -1) indexA = divisionOrder.length;
+            if (indexB == -1) indexB = divisionOrder.length;
+            return indexA.compareTo(indexB);
+          });
+
+          for (final divisionName in sortedDivisionNames) {
+            final divisionTeams = groupedByDivision[divisionName]!;
+            // Sort teams within the division alphabetically by full name
+            divisionTeams.sort((a, b) => a.fullName.compareTo(b.fullName));
+            divisionGroups.add(
+              DivisionGroup(divisionName: divisionName, teams: divisionTeams),
+            );
+          }
+
+          conferenceGroups.add(
+            ConferenceGroup(
+              conferenceName: conferenceName,
+              divisions: divisionGroups,
+            ),
+          );
+        }
+      }
+
+      // Return the final grouped and sorted structure
+      return AsyncData(conferenceGroups);
+    },
+    // Pass through loading and error states
+    loading: () => const AsyncLoading(),
+    error: (error, stackTrace) => AsyncError(error, stackTrace),
+  );
+});

--- a/lib/features/teams/ui/teams_screen.dart
+++ b/lib/features/teams/ui/teams_screen.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tackle_4_loss/core/constants/team_constants.dart'; // For getTeamLogoPath
+import 'package:tackle_4_loss/core/widgets/global_app_bar.dart';
+import 'package:tackle_4_loss/core/widgets/loading_indicator.dart';
+import 'package:tackle_4_loss/core/widgets/error_message.dart';
+import 'package:tackle_4_loss/features/teams/logic/teams_provider.dart'; // Import providers
+// --- Import the new layout constant ---
+import 'package:tackle_4_loss/core/constants/layout_constants.dart';
+
+class TeamsScreen extends ConsumerWidget {
+  const TeamsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final groupedTeamsAsync = ref.watch(groupedTeamsProvider);
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Scaffold(
+      appBar: const GlobalAppBar(title: Text('NFL Teams')),
+      body: groupedTeamsAsync.when(
+        data: (conferenceGroups) {
+          if (conferenceGroups.isEmpty) {
+            // --- Apply Center/ConstrainedBox to empty state too ---
+            // --- FIX: Removed const from Center ---
+            return Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: kMaxContentWidth),
+                child: const Text("No teams found."), // Text can be const here
+              ),
+            );
+          }
+          // --- Wrap the CustomScrollView ---
+          return Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: kMaxContentWidth),
+              child: CustomScrollView(
+                slivers: [
+                  // Iterate through conferences (AFC, NFC)
+                  for (final conferenceGroup in conferenceGroups) ...[
+                    // Conference Header - Now with Logo
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(
+                          16.0,
+                          24.0,
+                          16.0,
+                          8.0,
+                        ),
+                        child: Row(
+                          children: [
+                            // Conference Logo
+                            Image.asset(
+                              getTeamLogoPath(conferenceGroup.conferenceName),
+                              height: 40,
+                              width: 40,
+                              errorBuilder: (ctx, err, st) {
+                                debugPrint(
+                                  "Error loading logo for ${conferenceGroup.conferenceName}: $err",
+                                );
+                                return const Icon(
+                                  Icons.sports_football,
+                                  size: 40,
+                                );
+                              },
+                            ),
+                            const SizedBox(width: 12),
+                            // Conference Name
+                            Expanded(
+                              child: Text(
+                                getTeamFullName(conferenceGroup.conferenceName),
+                                style: textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  color: theme.colorScheme.primary,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    // Iterate through divisions within the conference
+                    for (final divisionGroup in conferenceGroup.divisions) ...[
+                      // Division Header
+                      SliverToBoxAdapter(
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(
+                            16.0,
+                            12.0,
+                            16.0,
+                            4.0,
+                          ),
+                          child: Text(
+                            divisionGroup.divisionName,
+                            style: textTheme.titleLarge,
+                          ),
+                        ),
+                      ),
+                      // Team List for the division
+                      SliverList(
+                        delegate: SliverChildBuilderDelegate((context, index) {
+                          final team = divisionGroup.teams[index];
+                          final logoPath = getTeamLogoPath(team.teamId);
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal:
+                                  8.0, // Padding within the constrained width
+                              vertical: 2.0,
+                            ),
+                            child: Card(
+                              elevation: 0.5,
+                              margin: EdgeInsets.zero,
+                              child: ListTile(
+                                leading: Image.asset(
+                                  logoPath,
+                                  height: 30,
+                                  width: 30,
+                                  errorBuilder: (ctx, err, st) {
+                                    debugPrint(
+                                      "Error loading logo $logoPath: $err",
+                                    );
+                                    return const Icon(
+                                      Icons.sports_football,
+                                      size: 30,
+                                    );
+                                  },
+                                ),
+                                title: Text(team.fullName),
+                                onTap: () {
+                                  debugPrint("Tapped on ${team.fullName}");
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        'Team details for ${team.fullName} not implemented yet.',
+                                      ),
+                                      duration: const Duration(seconds: 2),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          );
+                        }, childCount: divisionGroup.teams.length),
+                      ),
+                      const SliverToBoxAdapter(child: SizedBox(height: 16)),
+                    ],
+                  ],
+                  const SliverToBoxAdapter(child: SizedBox(height: 20)),
+                ],
+              ),
+            ),
+          );
+          // --- End Wrapping ---
+        },
+        // --- Apply Center/ConstrainedBox to loading/error states ---
+        // --- FIX: Removed const from Center ---
+        loading:
+            () => Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: kMaxContentWidth),
+                // LoadingIndicator itself is const, so this child can be const
+                child: const LoadingIndicator(),
+              ),
+            ),
+        error:
+            (error, stackTrace) => Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: kMaxContentWidth),
+                child: Padding(
+                  // Add padding around error message
+                  padding: const EdgeInsets.all(16.0),
+                  // ErrorMessageWidget is not const because of the callback
+                  child: ErrorMessageWidget(
+                    message: 'Failed to load teams: $error',
+                    onRetry: () => ref.invalidate(allTeamsProvider),
+                  ),
+                ),
+              ),
+            ),
+        // --- End Wrapping ---
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,7 +130,7 @@ packages:
     source: hosted
     version: "1.1.2"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   share_plus: ^10.1.4
   firebase_core: ^3.13.0
   firebase_messaging: ^15.2.5
+  collection: ^1.19.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This commit introduces the Teams feature, including the TeamInfo model, TeamService for fetching teams from the Supabase backend, and the TeamsScreen for displaying grouped teams by conference and division.

The new layout constants improve the UI's responsiveness, and the overall structure enhances maintainability. This feature allows users to view NFL teams, with
error handling and loading states implemented for a better user experience.