### PR TITLE
Add navigation to article detail screens and update UI components

### DIFF
--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -54,7 +54,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "1"
+      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/lib/core/widgets/global_app_bar.dart
+++ b/lib/core/widgets/global_app_bar.dart
@@ -26,7 +26,7 @@ class GlobalAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final iconTheme = Theme.of(context).iconTheme;
     final defaultTitle = Image.asset(
       'assets/images/logo.jpg',
-      height: 35,
+      height: 150,
     ); // Default app logo
 
     debugPrint(

--- a/lib/features/all_news/ui/all_news_screen.dart
+++ b/lib/features/all_news/ui/all_news_screen.dart
@@ -8,6 +8,8 @@ import 'package:tackle_4_loss/core/widgets/error_message.dart';
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
 import 'package:tackle_4_loss/core/widgets/global_app_bar.dart';
 import 'package:tackle_4_loss/core/constants/team_constants.dart';
+import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
+import 'package:tackle_4_loss/features/article_detail/ui/article_detail_screen.dart';
 
 const double kMaxContentWidth = 1200.0;
 
@@ -35,6 +37,24 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  /// Navigate to article detail screen
+  /// This function updates the currentDetailArticleIdProvider state to show the article detail
+  void navigateToArticleDetail(int articleId) {
+    ref.read(currentDetailArticleIdProvider.notifier).state = articleId;
+    debugPrint(
+      'AllNewsScreen: Navigating to article detail for articleId: $articleId',
+    );
+    // --- Added navigation to ArticleDetailScreen ---
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => ArticleDetailScreen(articleId: articleId),
+      ),
+    );
+    debugPrint(
+      'AllNewsScreen: Pushed ArticleDetailScreen for articleId: $articleId',
+    );
   }
 
   void _onScroll() {
@@ -229,7 +249,12 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                   slivers: [
                     if (headlineArticle != null)
                       SliverToBoxAdapter(
-                        child: HeadlineStoryCard(article: headlineArticle),
+                        child: InkWell(
+                          onTap:
+                              () =>
+                                  navigateToArticleDetail(headlineArticle!.id),
+                          child: HeadlineStoryCard(article: headlineArticle),
+                        ),
                       ),
 
                     SliverPadding(
@@ -253,6 +278,20 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                             }
                             return ArticleListItem(
                               article: listArticlesToShow[index],
+                              onTap: () {
+                                debugPrint(
+                                  'AllNewsScreen: Navigating to detail for articleId: \\${listArticlesToShow[index].id}',
+                                );
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder:
+                                        (context) => ArticleDetailScreen(
+                                          articleId:
+                                              listArticlesToShow[index].id,
+                                        ),
+                                  ),
+                                );
+                              },
                             );
                           },
                           childCount:

--- a/lib/features/article_detail/ui/article_detail_screen.dart
+++ b/lib/features/article_detail/ui/article_detail_screen.dart
@@ -5,15 +5,20 @@ import 'package:intl/intl.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:share_plus/share_plus.dart';
 
-// Removed GlobalAppBar import as it's no longer used here
+// Add GlobalAppBar import back
+import 'package:tackle_4_loss/core/widgets/global_app_bar.dart';
 import 'package:tackle_4_loss/core/widgets/loading_indicator.dart';
 import 'package:tackle_4_loss/core/widgets/error_message.dart';
 import 'package:tackle_4_loss/core/providers/locale_provider.dart';
 import 'package:tackle_4_loss/features/article_detail/logic/article_detail_provider.dart';
 // Import navigation provider to trigger back navigation state change
 import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
-// Removed kMaxContentWidth import, handled by MainNavigationWrapper
+// Import layout constants for responsive design
+import 'package:tackle_4_loss/core/constants/layout_constants.dart';
+// Import AppColors for consistent theming
+import 'package:tackle_4_loss/core/theme/app_colors.dart';
 
 class ArticleDetailScreen extends ConsumerWidget {
   final int articleId;
@@ -49,203 +54,257 @@ class ArticleDetailScreen extends ConsumerWidget {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 
-    // --- NO Scaffold or AppBar here ---
+    // Log debugging information about our appBar construction
+    debugPrint(
+      'ArticleDetailScreen: Building screen for articleId: $articleId',
+    );
+    debugPrint('ArticleDetailScreen: Using GlobalAppBar with default app logo');
 
-    // Use a simple Container or Padding as the root if needed,
-    // otherwise the direct content widget is fine.
-    return articleAsyncValue.when(
-      loading: () => const LoadingIndicator(),
-      error:
-          (error, stackTrace) => Padding(
-            // Add padding around error msg
-            padding: const EdgeInsets.all(16.0),
-            child: ErrorMessageWidget(
-              message: 'Failed to load article details.\n${error.toString()}',
-              // Retry still invalidates the provider
-              onRetry: () => ref.invalidate(articleDetailProvider(articleId)),
-            ),
-          ),
-      data: (article) {
-        final localeCode = currentLocale.languageCode;
-        final headline = article.getLocalizedHeadline(localeCode);
-        final htmlContent = article.getLocalizedContent(localeCode);
-        final primaryImageUrl = article.primaryImageUrl;
-        final sourceUri =
-            article.sourceUrl != null ? Uri.tryParse(article.sourceUrl!) : null;
-
-        // --- Content is wrapped in SingleChildScrollView ---
-        // The Center and ConstrainedBox are now handled by MainNavigationWrapper
-        return SingleChildScrollView(
-          // Add padding here for the content area
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // --- NEW: Back Button ---
-              Padding(
-                padding: const EdgeInsets.only(
-                  bottom: 12.0,
-                ), // Space below button
-                child: TextButton.icon(
-                  icon: const Icon(Icons.arrow_back_ios, size: 16),
-                  label: const Text('Back to News'), // Or just 'Back'
-                  style: TextButton.styleFrom(
-                    // Visual density compact to make it less intrusive
-                    visualDensity: VisualDensity.compact,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 8,
-                      vertical: 4,
-                    ),
-                  ),
+    // Implement proper scaffold pattern with GlobalAppBar
+    return Scaffold(
+      backgroundColor: AppColors.backgroundLight,
+      appBar: GlobalAppBar(
+        // Don't provide a title to ensure the default app logo is shown
+        // This ensures consistent branding across all screens
+        automaticallyImplyLeading: true, // Keep the back button in app bar
+        leading:
+            Navigator.canPop(context)
+                ? null
+                : IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  tooltip: 'Back',
                   onPressed: () {
-                    // Set the detail ID back to null to navigate away
+                    debugPrint(
+                      'ArticleDetailScreen: Custom back button pressed, resetting currentDetailArticleIdProvider',
+                    );
                     ref.read(currentDetailArticleIdProvider.notifier).state =
                         null;
                   },
                 ),
-              ),
-              // --- End Back Button ---
-
-              // 1. Primary Image
-              if (primaryImageUrl != null)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 16.0),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(12.0),
-                    child: CachedNetworkImage(
-                      imageUrl: primaryImageUrl,
-                      fit: BoxFit.cover,
-                      width: double.infinity,
-                      placeholder:
-                          (context, url) => Container(
-                            height: 250,
-                            color: Colors.grey[200],
-                            child: const Center(child: LoadingIndicator()),
-                          ),
-                      errorWidget:
-                          (context, url, error) => Container(
-                            height: 250,
-                            color: Colors.grey[200],
-                            child: Icon(
-                              Icons.broken_image_outlined,
-                              color: Colors.grey[500],
-                              size: 40,
-                            ),
-                          ),
-                    ),
-                  ),
-                ),
-              const SizedBox(height: 8),
-
-              // 2. Headline
-              Text(headline, style: textTheme.headlineMedium),
-              const SizedBox(height: 8),
-
-              // 3. Source & Date Row
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Flexible(
-                    child: Text(
-                      article.sourceName ?? 'Unknown Source',
-                      style: textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600],
-                        fontStyle: FontStyle.italic,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  const SizedBox(width: 10),
-                  if (article.createdAt != null)
-                    Text(
-                      DateFormat.yMMMd(localeCode).format(article.createdAt!),
-                      style: textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600],
-                      ),
-                    ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              const Divider(),
-              const SizedBox(height: 16),
-
-              // 4. Content
-              if (htmlContent != null && htmlContent.isNotEmpty)
-                Html(
-                  data: htmlContent,
-                  style: {
-                    "body": Style(
-                      fontSize: FontSize(textTheme.bodyLarge?.fontSize ?? 16.0),
-                      color: textTheme.bodyLarge?.color,
-                      lineHeight: LineHeight(
-                        textTheme.bodyLarge?.height ?? 1.5,
-                      ),
-                      margin: Margins.zero,
-                      padding: HtmlPaddings.zero,
-                    ),
-                    "p": Style(margin: Margins.only(bottom: 12.0)),
-                    "a": Style(
-                      color: theme.colorScheme.primary,
-                      textDecoration: TextDecoration.underline,
-                    ),
-                    "h1": Style(
-                      fontSize: FontSize(
-                        textTheme.headlineSmall?.fontSize ?? 20.0,
-                      ),
-                      fontWeight: textTheme.headlineSmall?.fontWeight,
-                      margin: Margins.symmetric(vertical: 10.0),
-                    ),
-                    "h2": Style(
-                      fontSize: FontSize(
-                        textTheme.titleLarge?.fontSize ?? 18.0,
-                      ),
-                      fontWeight: textTheme.titleLarge?.fontWeight,
-                      margin: Margins.symmetric(vertical: 8.0),
-                    ),
-                  },
-                  onLinkTap: (url, attributes, element) {
+        actions: articleAsyncValue.maybeWhen(
+          data:
+              (article) => [
+                // Share button only - removed refresh button
+                IconButton(
+                  icon: const Icon(Icons.share),
+                  onPressed: () {
+                    final title = article.getLocalizedHeadline(
+                      currentLocale.languageCode,
+                    );
+                    final url = article.sourceUrl;
                     if (url != null) {
-                      final uri = Uri.tryParse(url);
-                      if (uri != null) {
-                        _launchUrl(uri, context, ref);
-                      } else {
-                        debugPrint("Could not parse URL from HTML link: $url");
-                      }
+                      Share.share('$title\n\n$url');
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('No URL available to share'),
+                        ),
+                      );
                     }
                   },
-                )
-              else
-                Text(
-                  'Article content is not available.',
-                  style: textTheme.bodyLarge?.copyWith(
-                    fontStyle: FontStyle.italic,
-                    color: Colors.grey[600],
+                  tooltip: 'Share Article',
+                ),
+              ],
+          orElse: () => null,
+        ),
+      ),
+      // Apply responsive layout to body content
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: kMaxContentWidth),
+          child: articleAsyncValue.when(
+            loading: () => const Center(child: LoadingIndicator()),
+            error:
+                (error, stackTrace) => Padding(
+                  // Add padding around error msg
+                  padding: const EdgeInsets.all(16.0),
+                  child: ErrorMessageWidget(
+                    message:
+                        'Failed to load article details.\n${error.toString()}',
+                    // Retry still invalidates the provider
+                    onRetry:
+                        () => ref.invalidate(articleDetailProvider(articleId)),
                   ),
                 ),
-              const SizedBox(height: 24),
+            data: (article) {
+              final localeCode = currentLocale.languageCode;
+              final headline = article.getLocalizedHeadline(localeCode);
+              final htmlContent = article.getLocalizedContent(localeCode);
+              final primaryImageUrl = article.primaryImageUrl;
+              final sourceUri =
+                  article.sourceUrl != null
+                      ? Uri.tryParse(article.sourceUrl!)
+                      : null;
 
-              // 5. Source Link Button
-              if (sourceUri != null && article.sourceUrl != null)
-                Center(
-                  child: TextButton.icon(
-                    icon: const Icon(Icons.open_in_browser, size: 18),
-                    label: Text(
-                      'Read Full Article at ${article.sourceName ?? 'Source'}',
-                    ),
-                    onPressed: () => _launchUrl(sourceUri, context, ref),
-                    style: TextButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 10,
+              // --- Content is wrapped in SingleChildScrollView ---
+              return SingleChildScrollView(
+                // Add padding here for the content area
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16.0,
+                  vertical: 12.0,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Include article title at the top of the content for clarity
+                    // This way we keep the app logo in the AppBar but still prominently show the title
+                    Text(
+                      headline,
+                      style: textTheme.headlineMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
                       ),
                     ),
-                  ),
+                    const SizedBox(height: 8),
+
+                    // 1. Primary Image
+                    if (primaryImageUrl != null)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 16.0),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(12.0),
+                          child: CachedNetworkImage(
+                            imageUrl: primaryImageUrl,
+                            fit: BoxFit.cover,
+                            width: double.infinity,
+                            placeholder:
+                                (context, url) => Container(
+                                  height: 250,
+                                  color: Colors.grey[200],
+                                  child: const Center(
+                                    child: LoadingIndicator(),
+                                  ),
+                                ),
+                            errorWidget:
+                                (context, url, error) => Container(
+                                  height: 250,
+                                  color: Colors.grey[200],
+                                  child: Icon(
+                                    Icons.broken_image_outlined,
+                                    color: Colors.grey[500],
+                                    size: 40,
+                                  ),
+                                ),
+                          ),
+                        ),
+                      ),
+                    const SizedBox(height: 8),
+
+                    // Skip repeating headline as we added it at the top
+
+                    // 3. Source & Date Row
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Flexible(
+                          child: Text(
+                            article.sourceName ?? 'Unknown Source',
+                            style: textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                              fontStyle: FontStyle.italic,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        if (article.createdAt != null)
+                          Text(
+                            DateFormat.yMMMd(
+                              localeCode,
+                            ).format(article.createdAt!),
+                            style: textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    const Divider(),
+                    const SizedBox(height: 16),
+
+                    // 4. Content
+                    if (htmlContent != null && htmlContent.isNotEmpty)
+                      Html(
+                        data: htmlContent,
+                        style: {
+                          "body": Style(
+                            fontSize: FontSize(
+                              textTheme.bodyLarge?.fontSize ?? 16.0,
+                            ),
+                            color: textTheme.bodyLarge?.color,
+                            lineHeight: LineHeight(
+                              textTheme.bodyLarge?.height ?? 1.5,
+                            ),
+                            margin: Margins.zero,
+                            padding: HtmlPaddings.zero,
+                          ),
+                          "p": Style(margin: Margins.only(bottom: 12.0)),
+                          "a": Style(
+                            color: theme.colorScheme.primary,
+                            textDecoration: TextDecoration.underline,
+                          ),
+                          "h1": Style(
+                            fontSize: FontSize(
+                              textTheme.headlineSmall?.fontSize ?? 20.0,
+                            ),
+                            fontWeight: textTheme.headlineSmall?.fontWeight,
+                            margin: Margins.symmetric(vertical: 10.0),
+                          ),
+                          "h2": Style(
+                            fontSize: FontSize(
+                              textTheme.titleLarge?.fontSize ?? 18.0,
+                            ),
+                            fontWeight: textTheme.titleLarge?.fontWeight,
+                            margin: Margins.symmetric(vertical: 8.0),
+                          ),
+                        },
+                        onLinkTap: (url, attributes, element) {
+                          if (url != null) {
+                            final uri = Uri.tryParse(url);
+                            if (uri != null) {
+                              _launchUrl(uri, context, ref);
+                            } else {
+                              debugPrint(
+                                "Could not parse URL from HTML link: $url",
+                              );
+                            }
+                          }
+                        },
+                      )
+                    else
+                      Text(
+                        'Article content is not available.',
+                        style: textTheme.bodyLarge?.copyWith(
+                          fontStyle: FontStyle.italic,
+                          color: Colors.grey[600],
+                        ),
+                      ),
+                    const SizedBox(height: 24),
+
+                    // 5. Source Link Button
+                    if (sourceUri != null && article.sourceUrl != null)
+                      Center(
+                        child: TextButton.icon(
+                          icon: const Icon(Icons.open_in_browser, size: 18),
+                          label: Text(
+                            'Read Full Article at ${article.sourceName ?? 'Source'}',
+                          ),
+                          onPressed: () => _launchUrl(sourceUri, context, ref),
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 10,
+                            ),
+                          ),
+                        ),
+                      ),
+                    const SizedBox(height: 20),
+                  ],
                 ),
-              const SizedBox(height: 20),
-            ],
+              );
+            },
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/lib/features/my_team/ui/widgets/team_article_list.dart
+++ b/lib/features/my_team/ui/widgets/team_article_list.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tackle_4_loss/core/widgets/error_message.dart';
 import 'package:tackle_4_loss/core/widgets/loading_indicator.dart';
+import 'package:tackle_4_loss/features/article_detail/ui/article_detail_screen.dart';
 import 'package:tackle_4_loss/features/news_feed/data/news_feed_service.dart';
 import 'package:tackle_4_loss/features/news_feed/logic/news_feed_provider.dart'; // To get service provider
 import 'package:tackle_4_loss/features/news_feed/ui/widgets/article_list_item.dart'; // Reuse list item
@@ -46,7 +47,22 @@ class TeamArticleList extends ConsumerWidget {
             physics: const NeverScrollableScrollPhysics(),
             itemCount: articles.length,
             itemBuilder: (context, index) {
-              return ArticleListItem(article: articles[index]);
+              return ArticleListItem(
+                article: articles[index],
+                onTap: () {
+                  debugPrint(
+                    '[TeamArticleList] Navigating to detail for articleId: \\${articles[index].id}',
+                  );
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder:
+                          (context) => ArticleDetailScreen(
+                            articleId: articles[index].id,
+                          ),
+                    ),
+                  );
+                },
+              );
             },
           );
         }

--- a/lib/features/news_feed/ui/news_feed_screen.dart
+++ b/lib/features/news_feed/ui/news_feed_screen.dart
@@ -8,6 +8,7 @@ import 'package:tackle_4_loss/core/widgets/loading_indicator.dart';
 import 'package:tackle_4_loss/core/widgets/error_message.dart';
 import 'package:tackle_4_loss/core/providers/preference_provider.dart';
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
+import 'package:tackle_4_loss/features/article_detail/ui/article_detail_screen.dart';
 
 class NewsFeedScreen extends ConsumerStatefulWidget {
   // Make it const if possible
@@ -190,6 +191,19 @@ class _NewsFeedScreenState extends ConsumerState<NewsFeedScreen> {
                         }
                         return ArticleListItem(
                           article: listArticlesToShow[index],
+                          onTap: () {
+                            debugPrint(
+                              'NewsFeedScreen: Navigating to detail for articleId: \\${listArticlesToShow[index].id}',
+                            );
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder:
+                                    (context) => ArticleDetailScreen(
+                                      articleId: listArticlesToShow[index].id,
+                                    ),
+                              ),
+                            );
+                          },
                         );
                       },
                       childCount:

--- a/lib/features/news_feed/ui/widgets/article_list_item.dart
+++ b/lib/features/news_feed/ui/widgets/article_list_item.dart
@@ -13,8 +13,13 @@ import 'package:tackle_4_loss/core/constants/team_constants.dart';
 
 class ArticleListItem extends ConsumerWidget {
   final ArticlePreview article;
+  final VoidCallback onTap;
 
-  const ArticleListItem({super.key, required this.article});
+  const ArticleListItem({
+    super.key,
+    required this.article,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -33,9 +38,10 @@ class ArticleListItem extends ConsumerWidget {
     return Card(
       child: InkWell(
         onTap: () {
-          // --- MODIFIED: Update detail state instead of Navigator.push ---
-          ref.read(currentDetailArticleIdProvider.notifier).state = article.id;
-          // --- End Modification ---
+          debugPrint(
+            'ArticleListItem: onTap called for articleId: \\${article.id}',
+          );
+          onTap();
         },
         borderRadius: BorderRadius.circular(12.0),
         child: Padding(

--- a/lib/features/teams/ui/widgets/team_news_tab_content.dart
+++ b/lib/features/teams/ui/widgets/team_news_tab_content.dart
@@ -4,6 +4,7 @@ import 'package:tackle_4_loss/core/widgets/loading_indicator.dart';
 import 'package:tackle_4_loss/core/widgets/error_message.dart';
 import 'package:tackle_4_loss/features/news_feed/logic/news_feed_provider.dart'; // Provider for articles
 import 'package:tackle_4_loss/features/news_feed/ui/widgets/article_list_item.dart'; // Widget for list item
+import 'package:tackle_4_loss/features/article_detail/ui/article_detail_screen.dart';
 
 class TeamNewsTabContent extends ConsumerStatefulWidget {
   final String teamAbbreviation; // Team ID (e.g., "MIA")
@@ -117,7 +118,22 @@ class _TeamNewsTabContentState extends ConsumerState<TeamNewsTabContent> {
               }
               // Build the article list item
               if (index < articleList.length) {
-                return ArticleListItem(article: articleList[index]);
+                return ArticleListItem(
+                  article: articleList[index],
+                  onTap: () {
+                    debugPrint(
+                      'TeamNewsTabContent: Navigating to detail for articleId: \\${articleList[index].id}',
+                    );
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder:
+                            (context) => ArticleDetailScreen(
+                              articleId: articleList[index].id,
+                            ),
+                      ),
+                    );
+                  },
+                );
               }
               return Container(); // Should not happen
             },


### PR DESCRIPTION
This commit introduces navigation functionality to the article detail screens from various list views, enhancing user experience by allowing users to view detailed articles. The `ArticleListItem` widget has been modified to accept an `onTap` callback, enabling navigation when an article is tapped.

Additionally, the `GlobalAppBar` is reinstated in the `ArticleDetailScreen` to maintain consistent branding across the app. The layout has been adjusted for better responsiveness and clarity, ensuring that the article's title and content are prominently displayed.