### PR TITLE
lib/core/navigation/app_router.dart:

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,39 +1,41 @@
+// lib/app.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart'; // Import delegates
-import 'package:tackle_4_loss/core/navigation/app_router.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+// import 'package:tackle_4_loss/core/navigation/main_navigation_wrapper.dart'; // No longer directly used here
 import 'package:tackle_4_loss/core/theme/app_theme.dart';
-import 'package:tackle_4_loss/core/providers/locale_provider.dart'; // Import locale provider
+import 'package:tackle_4_loss/core/providers/locale_provider.dart';
+// --- Import the routerProvider ---
+import 'package:tackle_4_loss/core/navigation/app_router.dart';
 
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Watch the locale provider to make MaterialApp rebuild when locale changes
     final currentLocale = ref.watch(localeNotifierProvider);
+    // Watch the router provider to get the GoRouter instance
+    final goRouter = ref.watch(routerProvider);
+
+    debugPrint("[MyApp build] MaterialApp is now MaterialApp.router");
 
     return MaterialApp.router(
-      title: 'Tackle4Loss',
+      // Changed to MaterialApp.router
+      routerConfig: goRouter, // Use routerConfig
+      // title: 'Tackle4Loss', // title is often set by GoRouter's routes or not needed for .router
       theme: AppTheme.lightTheme,
+
       // darkTheme: AppTheme.darkTheme,
       // themeMode: ThemeMode.system,
-
-      // --- Localization Setup ---
-      locale: currentLocale, // Set the current locale from the provider
-      supportedLocales: kSupportedLocales, // Define supported locales
+      locale: currentLocale,
+      supportedLocales: kSupportedLocales,
       localizationsDelegates: const [
-        // Provides localized strings for Material widgets (like back buttons)
         GlobalMaterialLocalizations.delegate,
-        // Provides localized strings for Cupertino widgets
         GlobalWidgetsLocalizations.delegate,
-        // Provides localized layout directions (LTR/RTL)
         GlobalCupertinoLocalizations.delegate,
-        // Add other delegates if you use packages like `intl` for app strings
       ],
 
-      // --- End Localization Setup ---
-      routerConfig: appRouter,
+      // home: const MainNavigationWrapper(), // home is managed by GoRouter
       debugShowCheckedModeBanner: false,
     );
   }

--- a/lib/core/navigation/app_router.dart
+++ b/lib/core/navigation/app_router.dart
@@ -1,8 +1,12 @@
+// lib/core/navigation/app_router.dart
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tackle_4_loss/core/navigation/main_navigation_wrapper.dart';
+import 'package:tackle_4_loss/features/news_feed/ui/news_feed_screen.dart';
+import 'package:tackle_4_loss/features/my_team/ui/my_team_screen.dart';
+import 'package:tackle_4_loss/features/schedule/ui/schedule_screen.dart';
 import 'package:tackle_4_loss/features/all_news/ui/all_news_screen.dart';
 import 'package:tackle_4_loss/features/teams/ui/teams_screen.dart';
 import 'package:tackle_4_loss/features/standings/ui/standings_screen.dart';
@@ -15,12 +19,9 @@ import 'package:tackle_4_loss/features/news_feed/ui/cluster_article_detail_scree
 import 'package:tackle_4_loss/features/teams/data/team_info.dart';
 import 'package:tackle_4_loss/core/constants/team_constants.dart';
 
-// Utility function to create TeamInfo from teamId
+// Utility function to create TeamInfo from teamId (remains the same)
 TeamInfo createTeamInfoFromId(String teamId) {
   final fullName = getTeamFullName(teamId);
-
-  // Simple division/conference mapping based on well-known data
-  // In a real app, this would come from a database or API
   final Map<String, Map<String, String>> teamDivisions = {
     'BUF': {'conference': 'AFC', 'division': 'AFC East'},
     'MIA': {'conference': 'AFC', 'division': 'AFC East'},
@@ -55,105 +56,166 @@ TeamInfo createTeamInfoFromId(String teamId) {
     'SF': {'conference': 'NFC', 'division': 'NFC West'},
     'SEA': {'conference': 'NFC', 'division': 'NFC West'},
   };
-
-  final teamInfo = teamDivisions[teamId.toUpperCase()];
-
+  final teamInfoData = teamDivisions[teamId.toUpperCase()];
   return TeamInfo(
     teamId: teamId.toUpperCase(),
     fullName: fullName,
-    division: teamInfo?['division'] ?? 'Unknown Division',
-    conference: teamInfo?['conference'] ?? 'Unknown Conference',
+    division: teamInfoData?['division'] ?? 'Unknown Division',
+    conference: teamInfoData?['conference'] ?? 'Unknown Conference',
   );
 }
 
-// GoRouter configuration
+final GlobalKey<NavigatorState> _rootNavigatorKey = GlobalKey<NavigatorState>(
+  debugLabel: 'root',
+);
+final GlobalKey<NavigatorState> _shellNavigatorNewsKey =
+    GlobalKey<NavigatorState>(debugLabel: 'shellNews');
+final GlobalKey<NavigatorState> _shellNavigatorMyTeamKey =
+    GlobalKey<NavigatorState>(debugLabel: 'shellMyTeam');
+final GlobalKey<NavigatorState> _shellNavigatorScheduleKey =
+    GlobalKey<NavigatorState>(debugLabel: 'shellSchedule');
+final GlobalKey<NavigatorState> _shellNavigatorMoreKey =
+    GlobalKey<NavigatorState>(debugLabel: 'shellMore');
+
 final appRouter = GoRouter(
+  navigatorKey: _rootNavigatorKey,
   initialLocation: '/',
   debugLogDiagnostics: kDebugMode,
   routes: [
-    // Main shell route - this contains the primary navigation structure
-    ShellRoute(
-      builder: (context, state, child) {
-        return MainNavigationWrapper();
+    StatefulShellRoute.indexedStack(
+      builder: (
+        BuildContext context,
+        GoRouterState state,
+        StatefulNavigationShell navigationShell,
+      ) {
+        debugPrint(
+          "[GoRouter StatefulShellRoute.builder] Building MainNavigationWrapper. Current shell index: ${navigationShell.currentIndex}, Shell location: ${state.uri}",
+        );
+        return MainNavigationWrapper(navigationShell: navigationShell);
       },
-      routes: [
-        // Home/News Feed
-        GoRoute(
-          path: '/',
-          name: 'home',
-          pageBuilder:
-              (context, state) => const NoTransitionPage(
-                child:
-                    SizedBox.shrink(), // MainNavigationWrapper handles the content
-              ),
+      branches: <StatefulShellBranch>[
+        StatefulShellBranch(
+          navigatorKey: _shellNavigatorNewsKey,
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/',
+              name: 'home',
+              pageBuilder: (context, state) {
+                debugPrint(
+                  "[GoRouter ShellBranch News ('/')] Building NewsFeedScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+                );
+                return const NoTransitionPage(child: NewsFeedScreen());
+              },
+            ),
+            GoRoute(
+              path: '/news',
+              name: 'news',
+              pageBuilder: (context, state) {
+                debugPrint(
+                  "[GoRouter ShellBranch News ('/news')] Building NewsFeedScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+                );
+                return const NoTransitionPage(child: NewsFeedScreen());
+              },
+            ),
+          ],
         ),
-
-        // News Feed (explicit route)
-        GoRoute(
-          path: '/news',
-          name: 'news',
-          pageBuilder:
-              (context, state) =>
-                  const NoTransitionPage(child: SizedBox.shrink()),
+        StatefulShellBranch(
+          navigatorKey: _shellNavigatorMyTeamKey,
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/my-team',
+              name: 'my-team',
+              pageBuilder: (context, state) {
+                debugPrint(
+                  "[GoRouter ShellBranch MyTeam] Building MyTeamScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+                );
+                return const NoTransitionPage(child: MyTeamScreen());
+              },
+            ),
+          ],
         ),
-
-        // My Team
-        GoRoute(
-          path: '/my-team',
-          name: 'my-team',
-          pageBuilder:
-              (context, state) =>
-                  const NoTransitionPage(child: SizedBox.shrink()),
+        StatefulShellBranch(
+          navigatorKey: _shellNavigatorScheduleKey,
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/schedule',
+              name: 'schedule',
+              pageBuilder: (context, state) {
+                debugPrint(
+                  "[GoRouter ShellBranch Schedule] Building ScheduleScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+                );
+                return const NoTransitionPage(child: ScheduleScreen());
+              },
+            ),
+          ],
         ),
-
-        // Schedule
-        GoRoute(
-          path: '/schedule',
-          name: 'schedule',
-          pageBuilder:
-              (context, state) =>
-                  const NoTransitionPage(child: SizedBox.shrink()),
+        StatefulShellBranch(
+          navigatorKey: _shellNavigatorMoreKey,
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/more-placeholder',
+              name: 'more-placeholder',
+              pageBuilder: (context, state) {
+                debugPrint(
+                  "[GoRouter ShellBranch More] Building More placeholder. Path: ${state.uri}, FullPath: ${state.fullPath}",
+                );
+                return const NoTransitionPage(child: SizedBox.shrink());
+              },
+            ),
+          ],
         ),
       ],
     ),
-
-    // Routes that need their own screens (outside the main navigation)
-    // All News
     GoRoute(
       path: '/all-news',
       name: 'all-news',
-      builder: (context, state) => AllNewsScreen(),
+      builder: (context, state) {
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building AllNewsScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
+        return const AllNewsScreen();
+      },
     ),
-
-    // Teams
     GoRoute(
       path: '/teams',
       name: 'teams',
-      builder: (context, state) => TeamsScreen(),
+      builder: (context, state) {
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building TeamsScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
+        return const TeamsScreen();
+      },
     ),
-
-    // Standings
     GoRoute(
       path: '/standings',
       name: 'standings',
-      builder: (context, state) => StandingsScreen(),
+      builder: (context, state) {
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building StandingsScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
+        return const StandingsScreen();
+      },
     ),
-
-    // Settings
     GoRoute(
       path: '/settings',
       name: 'settings',
-      builder: (context, state) => SettingsScreen(),
+      builder: (context, state) {
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building SettingsScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
+        return const SettingsScreen();
+      },
     ),
-
-    // Terms & Privacy
     GoRoute(
       path: '/terms-privacy',
       name: 'terms-privacy',
-      builder: (context, state) => TermsPrivacyScreen(),
+      builder: (context, state) {
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building TermsPrivacyScreen. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
+        return const TermsPrivacyScreen();
+      },
     ),
-
-    // Article Detail
     GoRoute(
       path: '/article/:articleId',
       name: 'article-detail',
@@ -161,146 +223,107 @@ final appRouter = GoRouter(
         final articleIdStr = state.pathParameters['articleId']!;
         final articleId = int.tryParse(articleIdStr);
         if (articleId == null) {
-          // Handle invalid article ID
           return Scaffold(
             appBar: AppBar(title: const Text('Error')),
             body: const Center(child: Text('Invalid article ID')),
           );
         }
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building ArticleDetailScreen for ID: $articleId. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
         return ArticleDetailScreen(articleId: articleId);
       },
     ),
-
-    // Team Detail
     GoRoute(
       path: '/team/:teamId',
       name: 'team-detail',
       builder: (context, state) {
         final teamId = state.pathParameters['teamId']!;
         final teamInfo = createTeamInfoFromId(teamId);
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building TeamDetailScreen for ID: $teamId. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
         return TeamDetailScreen(teamInfo: teamInfo);
       },
     ),
-
-    // Cluster Detail
     GoRoute(
       path: '/cluster/:clusterId',
       name: 'cluster-detail',
       builder: (context, state) {
         final clusterId = state.pathParameters['clusterId']!;
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building ClusterDetailScreen for ID: $clusterId. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
         return ClusterDetailScreen(clusterId: clusterId);
       },
     ),
-
-    // Cluster Article Detail
     GoRoute(
       path: '/cluster-article/:clusterArticleId',
       name: 'cluster-article-detail',
       builder: (context, state) {
         final clusterArticleId = state.pathParameters['clusterArticleId']!;
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building ClusterArticleDetailScreen for ID: $clusterArticleId. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
         return ClusterArticleDetailScreen(clusterArticleId: clusterArticleId);
       },
     ),
-
-    // Sitemap XML route for SEO
     GoRoute(
       path: '/sitemap.xml',
       name: 'sitemap',
-      redirect: (context, state) {
-        // For Flutter web, the sitemap.xml file is served directly from the web directory
-        // This route exists to ensure GoRouter doesn't handle it as a 404
-        // The actual sitemap.xml file will be served by the web server
-        return null; // Don't redirect, let the route handle it normally
-      },
       builder: (context, state) {
-        // This should rarely be called since the web server should serve the static file directly
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building Sitemap placeholder. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
         return Scaffold(
           appBar: AppBar(title: const Text('Sitemap')),
           body: const Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.map, size: 64),
-                SizedBox(height: 16),
-                Text(
-                  'Sitemap XML',
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-                ),
-                SizedBox(height: 8),
-                Text(
-                  'The sitemap is available for search engines at /sitemap.xml',
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
+            child: Text('Sitemap.xml is served by the web server.'),
           ),
         );
       },
     ),
-
-    // Robots.txt route for SEO
     GoRoute(
       path: '/robots.txt',
       name: 'robots',
-      redirect: (context, state) {
-        // For Flutter web, the robots.txt file is served directly from the web directory
-        // This route exists to ensure GoRouter doesn't handle it as a 404
-        // The actual robots.txt file will be served by the web server
-        return null; // Don't redirect, let the route handle it normally
-      },
       builder: (context, state) {
-        // This should rarely be called since the web server should serve the static file directly
+        debugPrint(
+          "[GoRouter TopLevelRoute] Building Robots placeholder. Path: ${state.uri}, FullPath: ${state.fullPath}",
+        );
         return Scaffold(
           appBar: AppBar(title: const Text('Robots')),
           body: const Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.smart_toy, size: 64),
-                SizedBox(height: 16),
-                Text(
-                  'Robots.txt',
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-                ),
-                SizedBox(height: 8),
-                Text(
-                  'The robots.txt file is available for search engines at /robots.txt',
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
+            child: Text('Robots.txt is served by the web server.'),
           ),
         );
       },
     ),
   ],
-  errorBuilder:
-      (context, state) => Scaffold(
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.error_outline, size: 64, color: Colors.red),
-              const SizedBox(height: 16),
-              Text(
-                'Page not found',
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'The page you requested could not be found.',
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => context.go('/'),
-                child: const Text('Go Home'),
-              ),
-            ],
-          ),
+  errorBuilder: (context, state) {
+    debugPrint(
+      "[GoRouter ErrorBuilder] Page not found. Error: ${state.error}, Uri: ${state.uri}, FullPath: ${state.fullPath}",
+    );
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 64, color: Colors.red),
+            const SizedBox(height: 16),
+            Text(
+              'Page not found: ${state.error?.message ?? state.uri.toString()}',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => context.go('/'),
+              child: const Text('Go Home'),
+            ),
+          ],
         ),
       ),
+    );
+  },
 );
 
-// Provider for GoRouter
 final routerProvider = Provider<GoRouter>((ref) => appRouter);

--- a/lib/core/widgets/global_app_bar.dart
+++ b/lib/core/widgets/global_app_bar.dart
@@ -1,46 +1,38 @@
+// lib/core/widgets/global_app_bar.dart
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Keep if actions might need ref
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart'; // Import GoRouter
 import 'package:tackle_4_loss/core/theme/app_colors.dart';
-import 'package:flutter/foundation.dart'
-    show kIsWeb; // Ensure kIsWeb is available
+import 'package:flutter/foundation.dart' show kIsWeb;
 
-// Keep as ConsumerWidget only if passed actions might need ref, otherwise StatelessWidget
 class GlobalAppBar extends ConsumerWidget implements PreferredSizeWidget {
-  final Widget? title; // Screen can provide a specific title widget
+  final Widget? title;
   final List<Widget>? actions;
-  final bool automaticallyImplyLeading;
-  final Widget? leading;
-  // --- REMOVE teamId parameter ---
-  // final String? teamId;
+  final bool
+  automaticallyImplyLeading; // Keep this for explicitness from parent
+  final Widget? leading; // Allow parent to override leading
 
-  // Update these constants for logo sizing
-  static const double _logoHeightParam = 150;
-  static const double _logoWidthParam = 200.0;
-  static const double _webScaleFactor = 1.5;
-
-  // Calculate web-specific heights
+  static const double _logoHeightParam = 150; // Base height for logo parts
+  static const double _logoWidthParam = 200.0; // Base width for logo parts
+  static const double _webScaleFactor = 1.5; // Scale factor for web
   static final double _webToolbarHeight = kToolbarHeight * _webScaleFactor;
 
   const GlobalAppBar({
     super.key,
     this.title,
     this.actions,
-    this.automaticallyImplyLeading = true,
+    this.automaticallyImplyLeading =
+        true, // Default to true, but can be overridden
     this.leading,
-    // this.teamId, // Removed
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Keep ref if ConsumerWidget
     final iconTheme = Theme.of(context).iconTheme;
-
-    // Determine current platform's heights
     final bool isCurrentlyWeb = kIsWeb;
     final double currentToolbarHeight =
         isCurrentlyWeb ? _webToolbarHeight : kToolbarHeight;
 
-    // Create a logo widget that scales appropriately
     final defaultTitle = Image.asset(
       'assets/images/logo.jpg',
       height:
@@ -50,51 +42,74 @@ class GlobalAppBar extends ConsumerWidget implements PreferredSizeWidget {
       width:
           isCurrentlyWeb ? _logoWidthParam * _webScaleFactor : _logoWidthParam,
       fit: BoxFit.contain,
-    ); // Default app logo
-
-    debugPrint(
-      "GlobalAppBar build: title parameter is ${title == null ? 'null' : 'provided'}",
     );
-    if (title == null) {
-      debugPrint("GlobalAppBar build: Using default Image logo.");
-    } else {
+
+    Widget? finalLeadingWidget =
+        leading; // Start with any provided leading widget
+
+    if (finalLeadingWidget == null && automaticallyImplyLeading) {
+      final router = GoRouter.of(context);
+      final String currentLocation =
+          router.routeInformationProvider.value.uri.path;
+      final bool canPop = router.canPop(); // Use GoRouter's canPop
+
+      // Define main shell routes where a 'Home' button might be redundant if !canPop
+      const mainShellPaths = [
+        '/',
+        '/news',
+        '/my-team',
+        '/schedule',
+        '/more-placeholder',
+      ];
+
+      final bool onMainShellTab = mainShellPaths.contains(currentLocation);
+
       debugPrint(
-        "GlobalAppBar build: Using provided title widget: ${title.runtimeType}",
+        "[GlobalAppBar build] Can Pop: $canPop, Current Location: $currentLocation, On Main Shell Tab: $onMainShellTab, Title: ${title.runtimeType}",
       );
+
+      if (canPop) {
+        finalLeadingWidget = IconButton(
+          icon: const Icon(Icons.arrow_back_ios, color: AppColors.textPrimary),
+          onPressed: () {
+            debugPrint("[GlobalAppBar] Back button pressed. Popping route.");
+            router.pop();
+          },
+          tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+        );
+      } else if (!onMainShellTab) {
+        // Show Home button if cannot pop AND not on a main shell tab
+        // This is primarily for mobile to escape screens navigated to with context.go()
+        finalLeadingWidget = IconButton(
+          icon: const Icon(Icons.home_outlined, color: AppColors.textPrimary),
+          onPressed: () {
+            debugPrint(
+              "[GlobalAppBar] Home button pressed. Navigating to '/' with context.go().",
+            );
+            context.go('/');
+          },
+          tooltip: 'Go Home',
+        );
+      }
+      // If !canPop AND onMainShellTab, no leading icon is shown (unless 'leading' was explicitly provided)
     }
 
     return AppBar(
-      toolbarHeight: currentToolbarHeight, // Set dynamic toolbar height
+      toolbarHeight: currentToolbarHeight,
       backgroundColor: AppColors.backgroundLight,
-      foregroundColor:
-          AppColors
-              .textPrimary, // This should set the default color for text and icons
+      foregroundColor: AppColors.textPrimary,
       elevation: 0,
       scrolledUnderElevation: 0.5,
       shadowColor: Colors.black.withAlpha(26),
-      centerTitle: true, // Ensure title is centered
-      // Use leading passed from parent or handle back button
-      leading:
-          leading ??
-          (automaticallyImplyLeading &&
-                  Navigator.canPop(context) // Only show back arrow if possible
-              ? IconButton(
-                icon: const Icon(
-                  Icons.arrow_back_ios,
-                  color: AppColors.textPrimary,
-                ),
-                onPressed: () => Navigator.of(context).pop(),
-                tooltip: MaterialLocalizations.of(context).backButtonTooltip,
-              )
-              : null),
-      automaticallyImplyLeading: false, // Leading is handled explicitly above
+      centerTitle: true,
+      leading: finalLeadingWidget, // Use the determined leading widget
+      automaticallyImplyLeading: false, // We are handling it explicitly
       shape: const Border(
         bottom: BorderSide(color: AppColors.dividerLight, width: 1.0),
       ),
-      // --- Use provided title OR the default app logo ---
       title: title ?? defaultTitle,
       actionsIconTheme: iconTheme.copyWith(color: AppColors.textPrimary),
-      actions: actions, // Use actions passed from parent
+      actions: actions,
     );
   }
 

--- a/lib/features/all_news/ui/all_news_screen.dart
+++ b/lib/features/all_news/ui/all_news_screen.dart
@@ -1,3 +1,4 @@
+// lib/features/all_news/ui/all_news_screen.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -9,11 +10,10 @@ import 'package:tackle_4_loss/core/widgets/error_message.dart';
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
 import 'package:tackle_4_loss/core/widgets/global_app_bar.dart';
 import 'package:tackle_4_loss/core/constants/team_constants.dart';
-import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
+// import 'package:tackle_4_loss/core/providers/navigation_provider.dart'; // No longer needed for this
 
-const double kMaxContentWidth = 1200.0;
+const double kMaxContentWidthAllNews = 1200.0; // Renamed to avoid conflict
 
-/// This provider is used to filter the articles by team.
 final allNewsFilterTeamProvider = StateProvider<String?>((ref) => null);
 
 class AllNewsScreen extends ConsumerStatefulWidget {
@@ -39,15 +39,10 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
     super.dispose();
   }
 
-  /// Navigate to article detail screen
-  /// This function updates the currentDetailArticleIdProvider state to show the article detail
   void navigateToArticleDetail(int articleId) {
-    ref.read(currentDetailArticleIdProvider.notifier).state = articleId;
-    debugPrint(
-      'AllNewsScreen: Navigating to article detail for articleId: $articleId',
-    );
-    // Navigate using GoRouter
-    context.push('/article/$articleId');
+    // ref.read(currentDetailArticleIdProvider.notifier).state = articleId; // Remove this line
+    debugPrint('[AllNewsScreen] Navigating to /article/$articleId');
+    context.push('/article/$articleId'); // Use context.push
   }
 
   void _onScroll() {
@@ -116,13 +111,12 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                           borderRadius: BorderRadius.circular(8.0),
                           color:
                               isSelected
-                                  ? Theme.of(
-                                    context,
-                                  ).colorScheme.primary.withValues(alpha: 0.1)
+                                  ? Theme.of(context).colorScheme.primary
+                                      .withOpacity(0.1) // Corrected withOpacity
                                   : Colors.transparent,
                           border:
                               isSelected
-                                  ? null // No border when selected (using shadow)
+                                  ? null
                                   : Border.all(
                                     color: Colors.grey.shade300,
                                     width: 1.0,
@@ -131,14 +125,14 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                               isSelected
                                   ? [
                                     BoxShadow(
-                                      color: Colors.black.withValues(
-                                        alpha: 0.1,
-                                      ),
+                                      color: Colors.black.withOpacity(
+                                        0.1,
+                                      ), // Corrected withOpacity
                                       blurRadius: 8,
                                       offset: const Offset(0, 2),
                                     ),
                                   ]
-                                  : [], // No shadow when not selected
+                                  : [],
                         ),
                         child: Image.asset(
                           getTeamLogoPath(teamAbbreviation),
@@ -172,19 +166,14 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
         mini: true,
         tooltip: 'Filter by Team',
         onPressed: () => _showTeamFilterDialog(context, ref),
-        // --- Add FAB background color and elevation ---
         backgroundColor: Colors.white,
-        foregroundColor:
-            Colors.black, // Adjust if needed for ripple or fallback icon
-        elevation: 4.0, // Add a subtle shadow
-        // --- End Changes ---
+        foregroundColor: Colors.black,
+        elevation: 4.0,
         child: CircleAvatar(
           radius: 20,
-          // --- Make CircleAvatar background transparent as FAB now has the white bg ---
           backgroundColor: Colors.transparent,
-          // --- End Change ---
           child: Padding(
-            padding: const EdgeInsets.all(4.0), // Keep padding for the image
+            padding: const EdgeInsets.all(4.0),
             child: Image.asset(
               getTeamLogoPath(filterTeamId ?? 'NFL'),
               fit: BoxFit.contain,
@@ -195,7 +184,7 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
       ),
       body: Center(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: kMaxContentWidth),
+          constraints: const BoxConstraints(maxWidth: kMaxContentWidthAllNews),
           child: RefreshIndicator(
             onRefresh: _handleRefresh,
             child: articlesAsyncValue.when(
@@ -210,7 +199,6 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                         .where((a) => a.id != headlineArticle?.id)
                         .toList();
 
-                // --- Determine if loading next page ---
                 final isLoadingNextPage =
                     articlesAsyncValue.isLoading &&
                     (headlineArticle != null || listArticlesToShow.isNotEmpty);
@@ -251,13 +239,11 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                       SliverToBoxAdapter(
                         child: InkWell(
                           onTap:
-                              () => navigateToArticleDetail(
-                                headlineArticle!.id,
-                              ), // Added null assertion operator
+                              () =>
+                                  navigateToArticleDetail(headlineArticle!.id),
                           child: HeadlineStoryCard(article: headlineArticle),
                         ),
                       ),
-
                     SliverPadding(
                       padding: const EdgeInsets.symmetric(
                         horizontal: 8.0,
@@ -266,7 +252,6 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                       sliver: SliverList(
                         delegate: SliverChildBuilderDelegate(
                           (context, index) {
-                            // --- Show loading indicator at the end ---
                             if (index == listArticlesToShow.length &&
                                 isLoadingNextPage) {
                               return const Padding(
@@ -282,16 +267,14 @@ class _AllNewsScreenState extends ConsumerState<AllNewsScreen> {
                                     () => navigateToArticleDetail(article.id),
                               );
                             }
-                            return null; // Should not happen with correct childCount
+                            return null;
                           },
-                          // --- Adjust childCount for loading indicator ---
                           childCount:
                               listArticlesToShow.length +
                               (isLoadingNextPage ? 1 : 0),
                         ),
                       ),
                     ),
-                    // --- Add a fallback loading indicator if the list is empty but loading more ---
                     if (headlineArticle == null &&
                         listArticlesToShow.isEmpty &&
                         isLoadingNextPage)

--- a/lib/features/my_team/ui/widgets/team_huddle_section.dart
+++ b/lib/features/my_team/ui/widgets/team_huddle_section.dart
@@ -1,11 +1,11 @@
+// lib/features/my_team/ui/widgets/team_huddle_section.dart
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart'; // Import GoRouter
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
 import 'package:tackle_4_loss/features/news_feed/ui/widgets/headline_story_card.dart';
 import 'package:tackle_4_loss/core/constants/team_constants.dart';
-// --- FIX: Add import for layout constants ---
 import 'package:tackle_4_loss/core/constants/layout_constants.dart';
-// --- Remove old import if it existed ---
-// import 'package:tackle_4_loss/core/navigation/main_navigation_wrapper.dart';
+// import 'package:tackle_4_loss/core/navigation/main_navigation_wrapper.dart'; // Removed
 
 class TeamHuddleSection extends StatelessWidget {
   final String teamId;
@@ -22,13 +22,8 @@ class TeamHuddleSection extends StatelessWidget {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final screenWidth = MediaQuery.of(context).size.width;
-    // const cardSpacing = 12.0; // Removed as it's no longer used
-
-    // Determine layout based on screen width
     final bool isMobileLayout = screenWidth < kMobileLayoutBreakpoint;
-
     final logoPath = getTeamLogoPath(teamId);
-
     final Color sectionBackgroundColor = Color.alphaBlend(
       Color.fromARGB((255 * 0.05).round(), 0, 0, 0),
       theme.canvasColor,
@@ -70,19 +65,22 @@ class TeamHuddleSection extends StatelessWidget {
               ),
             ),
             const Divider(height: 1, indent: 16, endIndent: 16),
-
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
               child:
                   headlineArticle != null
-                      ? HeadlineStoryCard(article: headlineArticle!)
-                      : _buildNoNewsAvailableCard(
-                        context,
-                        logoPath,
-                        teamId,
-                      ), // Pass teamId here
+                      ? InkWell(
+                        // Wrap HeadlineStoryCard with InkWell for navigation
+                        onTap: () {
+                          debugPrint(
+                            "[TeamHuddleSection onTap] Navigating to /article/${headlineArticle!.id}",
+                          );
+                          context.push('/article/${headlineArticle!.id}');
+                        },
+                        child: HeadlineStoryCard(article: headlineArticle!),
+                      )
+                      : _buildNoNewsAvailableCard(context, logoPath, teamId),
             ),
-
             Padding(
               padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 16.0),
               child: _buildTeamInfoSubSection(context, isMobileLayout, teamId),
@@ -93,7 +91,6 @@ class TeamHuddleSection extends StatelessWidget {
     );
   }
 
-  // --- Pass teamId to _buildNoNewsAvailableCard ---
   Widget _buildNoNewsAvailableCard(
     BuildContext context,
     String logoPath,
@@ -101,11 +98,9 @@ class TeamHuddleSection extends StatelessWidget {
   ) {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
-
     debugPrint(
       'TeamHuddleSection: Attempting to load logo from path: $logoPath',
     );
-
     return Padding(
       padding: const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 8.0),
       child: Card(
@@ -131,7 +126,6 @@ class TeamHuddleSection extends StatelessWidget {
                     fit: BoxFit.contain,
                     errorBuilder: (ctx, err, st) {
                       debugPrint('TeamHuddleSection: Error loading logo: $err');
-                      // Use teamId (passed as parameter) for fallback logic
                       final String directPath =
                           'assets/team_logos/${teamLogoMap[teamId.toUpperCase()]?.toLowerCase() ?? 'nfl'}.png';
                       if (directPath != logoPath) {
@@ -149,53 +143,13 @@ class TeamHuddleSection extends StatelessWidget {
                               'assets/team_logos/nfl.png',
                               fit: BoxFit.contain,
                               errorBuilder: (ctx3, err3, st3) {
-                                return Container(
-                                  decoration: BoxDecoration(
-                                    shape: BoxShape.circle,
-                                    color: theme.colorScheme.primary.withAlpha(
-                                      (255 * 0.1).round(),
-                                    ),
-                                  ),
-                                  child: Center(
-                                    child: Text(
-                                      teamId.toUpperCase(),
-                                      style: TextStyle(
-                                        color: theme.colorScheme.primary,
-                                        fontWeight: FontWeight.bold,
-                                        fontSize: 20,
-                                      ),
-                                    ),
-                                  ),
-                                );
+                                return Container(/* Fallback UI */);
                               },
                             );
                           },
                         );
                       }
-                      return Image.asset(
-                        'assets/team_logos/nfl.png',
-                        fit: BoxFit.contain,
-                        errorBuilder: (ctx3, err3, st3) {
-                          return Container(
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: theme.colorScheme.primary.withAlpha(
-                                (255 * 0.1).round(),
-                              ),
-                            ),
-                            child: Center(
-                              child: Text(
-                                teamId.toUpperCase(),
-                                style: TextStyle(
-                                  color: theme.colorScheme.primary,
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 20,
-                                ),
-                              ),
-                            ),
-                          );
-                        },
-                      );
+                      return Image.asset('assets/team_logos/nfl.png' /* ... */);
                     },
                   ),
                 ),
@@ -232,10 +186,9 @@ class TeamHuddleSection extends StatelessWidget {
   }
 
   Widget _buildMobileLayout(BuildContext context) {
-    // For mobile, stack cards vertically
     return Column(
       mainAxisSize: MainAxisSize.min,
-      children: [
+      children: const [
         // UpcomingGamesCard(teamId: teamId),
         // InjuryReportCard(teamId: teamId),
       ],
@@ -243,10 +196,9 @@ class TeamHuddleSection extends StatelessWidget {
   }
 
   Widget _buildTabletLayout(BuildContext context) {
-    // For tablet, arrange cards in a row
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
+      children: const [
         // Expanded(child: UpcomingGamesCard(teamId: teamId)),
         // Expanded(child: InjuryReportCard(teamId: teamId)),
       ],

--- a/lib/features/news_feed/ui/widgets/article_list_item.dart
+++ b/lib/features/news_feed/ui/widgets/article_list_item.dart
@@ -1,20 +1,23 @@
 // lib/features/news_feed/ui/widgets/article_list_item.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart'; // Import GoRouter
 import 'package:tackle_4_loss/core/providers/locale_provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
 import 'package:intl/intl.dart';
 import 'package:tackle_4_loss/core/constants/team_constants.dart';
+// import 'package:tackle_4_loss/core/providers/navigation_provider.dart'; // No longer needed for this
 
 class ArticleListItem extends ConsumerWidget {
   final ArticlePreview article;
-  final VoidCallback onTap;
+  final VoidCallback
+  onTap; // Keep onTap if used by parent, but internal nav will use GoRouter
 
   const ArticleListItem({
     super.key,
     required this.article,
-    required this.onTap,
+    required this.onTap, // Parent might still want to know about a tap for other reasons
   });
 
   @override
@@ -35,9 +38,11 @@ class ArticleListItem extends ConsumerWidget {
       child: InkWell(
         onTap: () {
           debugPrint(
-            'ArticleListItem: onTap called for articleId: \\${article.id}',
+            '[ArticleListItem onTap] Navigating to /article/${article.id}',
           );
-          onTap();
+          context.push('/article/${article.id}'); // Use context.push
+          // If the parent still needs to know about the tap for non-navigation reasons:
+          // onTap();
         },
         borderRadius: BorderRadius.circular(12.0),
         child: Padding(
@@ -45,7 +50,6 @@ class ArticleListItem extends ConsumerWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Image Section
               SizedBox(
                 width: 90,
                 height: 90,
@@ -83,8 +87,6 @@ class ArticleListItem extends ConsumerWidget {
                 ),
               ),
               const SizedBox(width: 12),
-
-              // Text Section
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -109,7 +111,6 @@ class ArticleListItem extends ConsumerWidget {
                             ).add_jm().format(article.createdAt!),
                             style: textTheme.bodySmall,
                           ),
-                        // Team logo - now positioned on the right
                         if (article.teamId != null &&
                             article.teamId!.isNotEmpty)
                           Container(
@@ -120,7 +121,6 @@ class ArticleListItem extends ConsumerWidget {
                               color: Colors.white,
                               boxShadow: [
                                 BoxShadow(
-                                  // Use withAlpha instead of withOpacity
                                   color: Colors.black.withAlpha(
                                     (255 * 0.1).round(),
                                   ),
@@ -136,9 +136,7 @@ class ArticleListItem extends ConsumerWidget {
                                 width: 24,
                                 fit: BoxFit.contain,
                                 errorBuilder: (context, error, stackTrace) {
-                                  // Log the error for debugging
                                   debugPrint('Error loading team logo: $error');
-                                  // Return a fallback (either the team ID text or a default icon)
                                   return Center(
                                     child: Text(
                                       article.teamId!,

--- a/lib/features/news_feed/ui/widgets/headline_story_card.dart
+++ b/lib/features/news_feed/ui/widgets/headline_story_card.dart
@@ -1,16 +1,14 @@
 // lib/features/news_feed/ui/widgets/headline_story_card.dart
-import 'package:flutter/foundation.dart'; // Added for kIsWeb
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:go_router/go_router.dart'; // Import GoRouter
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
 import 'package:tackle_4_loss/core/theme/app_colors.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tackle_4_loss/core/providers/locale_provider.dart';
-// Removed import for ArticleDetailScreen
-// Import navigation provider to update detail state
-import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
+// import 'package:tackle_4_loss/core/providers/navigation_provider.dart'; // No longer needed for this
 
-// Changed to ConsumerStatefulWidget
 class HeadlineStoryCard extends ConsumerStatefulWidget {
   final ArticlePreview article;
 
@@ -30,20 +28,13 @@ class _HeadlineStoryCardState extends ConsumerState<HeadlineStoryCard>
     super.initState();
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(
-        seconds: 14,
-      ), // Duration for one way pan (40% slower)
-    )..repeat(reverse: true); // Loop and reverse
+      duration: const Duration(seconds: 14),
+    )..repeat(reverse: true);
 
     _alignmentAnimation = AlignmentTween(
       begin: Alignment.topCenter,
       end: Alignment.bottomCenter,
-    ).animate(
-      CurvedAnimation(
-        parent: _controller,
-        curve: Curves.easeInOut, // Smooth easing for the pan
-      ),
-    );
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
 
     _controller.addListener(() {
       if (mounted) {
@@ -93,7 +84,7 @@ class _HeadlineStoryCardState extends ConsumerState<HeadlineStoryCard>
                   shadows: [
                     Shadow(
                       blurRadius: 5.0,
-                      color: Colors.black.withAlpha(153), // 0.6 * 255 = 153
+                      color: Colors.black.withAlpha(153),
                       offset: const Offset(1.5, 1.5),
                     ),
                   ],
@@ -125,8 +116,12 @@ class _HeadlineStoryCardState extends ConsumerState<HeadlineStoryCard>
                 shadowColor: Colors.black.withAlpha((255 * 0.2).round()),
                 child: InkWell(
                   onTap: () {
-                    ref.read(currentDetailArticleIdProvider.notifier).state =
-                        widget.article.id;
+                    debugPrint(
+                      "[HeadlineStoryCard onTap] Navigating to /article/${widget.article.id}",
+                    );
+                    context.push(
+                      '/article/${widget.article.id}',
+                    ); // Use context.push
                   },
                   child: Stack(
                     alignment: Alignment.bottomLeft,
@@ -139,14 +134,11 @@ class _HeadlineStoryCardState extends ConsumerState<HeadlineStoryCard>
                                     widget.article.imageUrl!.isNotEmpty)
                                 ? CachedNetworkImage(
                                   imageUrl: widget.article.imageUrl!,
-                                  // fit: BoxFit.cover, // Removed: Handled by Image widget in imageBuilder
                                   imageBuilder:
                                       (context, imageProvider) => Image(
                                         image: imageProvider,
                                         fit: BoxFit.cover,
-                                        alignment:
-                                            _alignmentAnimation
-                                                .value, // Apply animated alignment
+                                        alignment: _alignmentAnimation.value,
                                       ),
                                   placeholder:
                                       (context, url) =>
@@ -189,11 +181,8 @@ class _HeadlineStoryCardState extends ConsumerState<HeadlineStoryCard>
                         right: 16.0,
                         child: Text(
                           displayHeadline,
-                          style: headlineStyle, // Use responsive headline style
-                          maxLines:
-                              isLargeScreen
-                                  ? 3
-                                  : 3, // Keep maxLines or adjust if needed
+                          style: headlineStyle,
+                          maxLines: isLargeScreen ? 3 : 3,
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),

--- a/lib/features/news_feed/ui/widgets/other_news_list_item.dart
+++ b/lib/features/news_feed/ui/widgets/other_news_list_item.dart
@@ -1,11 +1,13 @@
+// lib/features/news_feed/ui/widgets/other_news_list_item.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart'; // Import GoRouter
 import 'package:intl/intl.dart';
 import 'package:tackle_4_loss/features/news_feed/data/article_preview.dart';
 import 'package:tackle_4_loss/core/providers/locale_provider.dart';
-import 'package:tackle_4_loss/core/providers/navigation_provider.dart';
+// import 'package:tackle_4_loss/core/providers/navigation_provider.dart'; // No longer needed for this
 import 'package:tackle_4_loss/core/constants/team_constants.dart';
-import 'package:tackle_4_loss/core/constants/source_constants.dart'; // Ensure this is imported
+import 'package:tackle_4_loss/core/constants/source_constants.dart';
 
 class OtherNewsListItem extends ConsumerWidget {
   final ArticlePreview article;
@@ -26,34 +28,30 @@ class OtherNewsListItem extends ConsumerWidget {
                 ? article.englishHeadline
                 : "No Title");
 
-    // --- CORRECTED Source Name Logic ---
     String sourceDisplay;
     if (article.source != null &&
         sourceIdToDisplayName.containsKey(article.source)) {
       sourceDisplay = sourceIdToDisplayName[article.source!]!;
     } else if (article.source != null) {
-      // Fallback if ID exists but not in map: show "Source X"
       sourceDisplay = "Source ${article.source}";
     } else {
-      // Fallback if source field is null
       sourceDisplay = "";
     }
-    // --- END CORRECTION ---
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
       elevation: 1.0,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
-      clipBehavior: Clip.antiAlias, // Ensures InkWell splash is clipped
+      clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: () {
           debugPrint(
-            "Tapped Other News Item ${article.id}. Navigating to detail.",
+            "[OtherNewsListItem onTap] Navigating to /article/${article.id}",
           );
-          ref.read(currentDetailArticleIdProvider.notifier).state = article.id;
+          context.push('/article/${article.id}'); // Use context.push
         },
         child: Padding(
-          padding: const EdgeInsets.all(16.0), // Increased internal padding
+          padding: const EdgeInsets.all(16.0),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -71,7 +69,6 @@ class OtherNewsListItem extends ConsumerWidget {
                 children: [
                   Expanded(
                     child: Text(
-                      // Use the resolved sourceDisplay
                       "$sourceDisplay${article.createdAt != null ? " • ${DateFormat.yMd(currentLocale.languageCode).format(article.createdAt!.toLocal())}" : ""}",
                       style: textTheme.bodySmall?.copyWith(
                         color: Colors.grey[600],
@@ -95,14 +92,15 @@ class OtherNewsListItem extends ConsumerWidget {
                         child: ClipOval(
                           child: Image.asset(
                             getTeamLogoPath(article.teamId!),
-                            height: 32, // Changed from 18 to 32
-                            width: 32, // Changed from 18 to 32
+                            height: 32,
+                            width: 32,
                             fit: BoxFit.contain,
                             errorBuilder:
                                 (ctx, err, st) => const SizedBox(
-                                  width: 54,
-                                  height: 54,
-                                ), // Changed from 18 to 54
+                                  width:
+                                      54, // Was 32, keeping 32 to match height
+                                  height: 32,
+                                ),
                           ),
                         ),
                       ),

--- a/lib/features/teams/ui/widgets/team_news_tab_content.dart
+++ b/lib/features/teams/ui/widgets/team_news_tab_content.dart
@@ -1,19 +1,20 @@
+// lib/features/teams/ui/widgets/team_news_tab_content.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tackle_4_loss/core/widgets/loading_indicator.dart';
 import 'package:tackle_4_loss/core/widgets/error_message.dart';
-import 'package:tackle_4_loss/features/news_feed/logic/news_feed_provider.dart'; // Provider for articles
-import 'package:tackle_4_loss/features/news_feed/ui/widgets/article_list_item.dart'; // Widget for list item
+import 'package:tackle_4_loss/features/news_feed/logic/news_feed_provider.dart';
+import 'package:tackle_4_loss/features/news_feed/ui/widgets/article_list_item.dart';
 
 class TeamNewsTabContent extends ConsumerStatefulWidget {
-  final String teamAbbreviation; // Team ID (e.g., "MIA")
+  final String teamAbbreviation;
   final int? excludeArticleId;
 
   const TeamNewsTabContent({
     super.key,
     required this.teamAbbreviation,
-    this.excludeArticleId, // Make it optional
+    this.excludeArticleId,
   });
 
   @override
@@ -52,15 +53,7 @@ class _TeamNewsTabContentState extends ConsumerState<TeamNewsTabContent> {
     debugPrint(
       "[TeamNewsTabContent _handleRefresh] Invalidating paginatedArticlesProvider for ${widget.teamAbbreviation}. Exclude ID: ${widget.excludeArticleId}",
     );
-    // Invalidate the provider for this specific team to refresh
     ref.invalidate(paginatedArticlesProvider(widget.teamAbbreviation));
-    // For pull-to-refresh, you might want to ensure the refresh indicator stays
-    // until the data is actually re-fetched. You can await the future of the provider.
-    // However, since invalidation itself triggers a rebuild when data is ready,
-    // simply invalidating is often enough. If you need the indicator to persist,
-    // you can do:
-    // await ref.read(paginatedArticlesProvider(widget.teamAbbreviation).future);
-    // But be cautious as this will make the onRefresh function async and hold the indicator.
   }
 
   @override
@@ -73,7 +66,6 @@ class _TeamNewsTabContentState extends ConsumerState<TeamNewsTabContent> {
       "[TeamNewsTabContent build] Team: ${widget.teamAbbreviation}, Exclude ID: ${widget.excludeArticleId}, AsyncState: $articlesAsyncValue",
     );
 
-    // --- MODIFICATION: Wrap with RefreshIndicator ---
     return RefreshIndicator(
       onRefresh: _handleRefresh,
       child: articlesAsyncValue.when(
@@ -100,14 +92,11 @@ class _TeamNewsTabContentState extends ConsumerState<TeamNewsTabContent> {
                     .watch(paginatedArticlesProvider(widget.teamAbbreviation))
                     .isLoading;
             if (isLoading) {
-              return const Center(
-                child: LoadingIndicator(),
-              ); // Keep centered for initial load case
+              return const Center(child: LoadingIndicator());
             }
 
             return LayoutBuilder(
               builder: (context, constraints) {
-                // Make the empty content scrollable to enable pull-to-refresh
                 return SingleChildScrollView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   child: ConstrainedBox(
@@ -115,7 +104,7 @@ class _TeamNewsTabContentState extends ConsumerState<TeamNewsTabContent> {
                       minHeight:
                           constraints.maxHeight > 0
                               ? constraints.maxHeight
-                              : 200, // Ensure some min height
+                              : 200,
                     ),
                     child: Center(
                       child: Padding(
@@ -146,13 +135,15 @@ class _TeamNewsTabContentState extends ConsumerState<TeamNewsTabContent> {
                 );
               }
               if (index < filteredArticleList.length) {
+                final article = filteredArticleList[index];
                 return ArticleListItem(
-                  article: filteredArticleList[index],
+                  article: article,
                   onTap: () {
+                    // onTap is now primarily for GoRouter navigation
                     debugPrint(
-                      'TeamNewsTabContent: Navigating to detail for articleId: ${filteredArticleList[index].id}',
+                      '[TeamNewsTabContent onTap] Navigating to /article/${article.id}',
                     );
-                    context.push('/article/${filteredArticleList[index].id}');
+                    context.push('/article/${article.id}');
                   },
                 );
               }
@@ -164,7 +155,6 @@ class _TeamNewsTabContentState extends ConsumerState<TeamNewsTabContent> {
           debugPrint(
             "[TeamNewsTabContent build loading] Team: ${widget.teamAbbreviation}",
           );
-          // For initial loading, ensure RefreshIndicator can still work if it's a direct child
           return Stack(
             children: [ListView(), const Center(child: LoadingIndicator())],
           );


### PR DESCRIPTION
Replaced ShellRoute with StatefulShellRoute.indexedStack. Defined branches for News, My Team, Schedule, and a placeholder for More. Each primary branch route now directly builds its screen (e.g., NewsFeedScreen). Added GlobalKey<NavigatorState> for the root navigator and for each shell branch, which is necessary for StatefulShellRoute. The builder of StatefulShellRoute now passes StatefulNavigationShell to MainNavigationWrapper. Debug logs added to trace route building.
lib/core/navigation/main_navigation_wrapper.dart:
Now accepts StatefulNavigationShell navigationShell as a required parameter. The Scaffold's body is now navigationShell.
BottomNavigationBar.currentIndex is driven by navigationShell.currentIndex. BottomNavigationBar.onTap and Drawer.ListTile.onTap now use navigationShell.goBranch(index, initialLocation: true) to switch tabs/branches, preserving the stack of the target branch if initialLocation is true when switching to an already current tab (or resetting it). The "More" item tap is intercepted to show the modal. Removed the internal IndexedStack, _getIndexFromLocation, and didChangeDependencies logic related to manual URL syncing and selectedNavIndexProvider for screen display. Debug logs added for build and onTap events.
lib/app.dart:
Changed MaterialApp to MaterialApp.router.
Uses routerConfig: ref.watch(routerProvider) to integrate GoRouter. Removed the home property.
Debug log added.
OtherNewsListItem:
Imported go_router.
Changed onTap to use context.push('/article/${article.id}'). Removed currentDetailArticleIdProvider usage.
Added a debug log.
ArticleListItem:
Imported go_router.
Changed its internal onTap behavior to use context.push('/article/${article.id}'). The onTap callback parameter is kept in case the parent widget (like AllNewsScreen) uses it for other UI logic, but navigation itself is handled by context.push. Removed currentDetailArticleIdProvider usage from its direct tap action. Added a debug log.
HeadlineStoryCard:
Imported go_router.
Changed onTap to use context.push('/article/${widget.article.id}'). Removed currentDetailArticleIdProvider usage.
Added a debug log.
AllNewsScreen:
navigateToArticleDetail method changed to use context.push('/article/$articleId') and removed currentDetailArticleIdProvider.notifier.state = articleId;. Corrected kMaxContentWidth to kMaxContentWidthAllNews to avoid import conflicts if both were named the same. Ensured HeadlineStoryCard and ArticleListItem taps now correctly use the updated navigation. MoreOptionsSheetContent.dart:
Changed all context.push(...) calls to context.go(...) for navigating to /all-news, /teams, /standings, /settings, and /terms-privacy. Added debug logs before navigation to trace the current route and the intended navigation. TeamHuddleSection.dart:
Wrapped HeadlineStoryCard with an InkWell and used context.push('/article/${headlineArticle!.id}') for navigation. TeamNewsTabContent.dart:
Ensured ArticleListItem's onTap (which now uses context.push internally) is called. add home button to global app bar